### PR TITLE
Swap basic contents of Welcome and Finish views

### DIFF
--- a/src/Views/FinishView.vala
+++ b/src/Views/FinishView.vala
@@ -18,21 +18,15 @@
 public class Onboarding.FinishView : AbstractOnboardingView {
     public FinishView () {
         Object (
-            description: _("Thanks for choosing %s!").printf (Utils.os_name),
+            description: _("You can change all %s settings and preferences any time from System Settings.").printf (Utils.os_name),
             icon_name: "process-completed",
-            title: _("All Done!")
+            title: _("Enjoy %s").printf (Utils.os_name)
         );
     }
 
     construct {
-        var thebasics_link = new Gtk.LinkButton.with_label ("https://elementary.io/docs/learning-the-basics#learning-the-basics", _("Learning The Basics"));
+        var link_button = new Gtk.LinkButton.with_label ("settings://", _("Open System Settings…"));
 
-        var support_link = new Gtk.LinkButton.with_label (Utils.support_url, _("Get Support"));
-
-        var getinvolved_link = new Gtk.LinkButton.with_label ("https://elementary.io/get-involved", _("Get Involved"));
-
-        custom_bin.attach (thebasics_link, 0, 0);
-        custom_bin.attach (support_link, 0, 1);
-        custom_bin.attach (getinvolved_link, 0, 2);
+        custom_bin.add (link_button);
     }
 }

--- a/src/Views/FinishView.vala
+++ b/src/Views/FinishView.vala
@@ -18,7 +18,7 @@
 public class Onboarding.FinishView : AbstractOnboardingView {
     public FinishView () {
         Object (
-            description: _("You can change all %s settings and preferences any time from System Settings.").printf (Utils.os_name),
+            description: _("You can visit System Settings any time."),
             icon_name: "process-completed",
             title: _("Enjoy %s").printf (Utils.os_name)
         );

--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -18,7 +18,7 @@
 public class Onboarding.WelcomeView : AbstractOnboardingView {
     public WelcomeView () {
         Object (
-            description: _("Set up some optional but useful features. You can also visit the links below for more information about %s.").printf (Utils.os_name),
+            description: _("Continue to set up some useful features. Visit the links below for more information about %s.").printf (Utils.os_name),
             icon_name: "distributor-logo",
             title: _("Welcome to %s!").printf (Utils.os_name)
         );

--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -18,15 +18,21 @@
 public class Onboarding.WelcomeView : AbstractOnboardingView {
     public WelcomeView () {
         Object (
-            description: _("You can skip this at any time to start using %s. The following settings can always be changed later.").printf (Utils.os_name),
+            description: _("Set up some optional but useful features. You can also visit the links below for more information about %s.").printf (Utils.os_name),
             icon_name: "distributor-logo",
             title: _("Welcome to %s!").printf (Utils.os_name)
         );
     }
 
     construct {
-        var link_button = new Gtk.LinkButton.with_label ("settings://", _("Open System Settings…"));
+        var thebasics_link = new Gtk.LinkButton.with_label ("https://elementary.io/docs/learning-the-basics#learning-the-basics", _("Learning The Basics"));
 
-        custom_bin.add (link_button);
+        var support_link = new Gtk.LinkButton.with_label (Utils.support_url, _("Get Support"));
+
+        var getinvolved_link = new Gtk.LinkButton.with_label ("https://elementary.io/get-involved", _("Get Involved"));
+
+        custom_bin.attach (thebasics_link, 0, 0);
+        custom_bin.attach (support_link, 0, 1);
+        custom_bin.attach (getinvolved_link, 0, 2);
     }
 }


### PR DESCRIPTION
@danrabbit and I were talking that the resources make more sense up front, and System Settings at the end. So this swaps them and tweaks the copy to make sense in the new context. Fixes #21.

![image](https://user-images.githubusercontent.com/611168/56086295-541aac80-5e11-11e9-81c1-feee6228fc64.png)

![image](https://user-images.githubusercontent.com/611168/56086407-f76cc100-5e13-11e9-8a48-dfa273d76994.png)


