### PR TITLE
No skip stack transition

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -55,7 +55,7 @@ public class Onboarding.MainWindow : Gtk.Window {
 
         var skip_revealer = new Gtk.Revealer ();
         skip_revealer.reveal_child = true;
-        skip_revealer.transition_type = Gtk.RevealerTransitionType.CROSSFADE;
+        skip_revealer.transition_type = Gtk.RevealerTransitionType.NONE;
         skip_revealer.add (skip_button);
 
         var stack_switcher = new Gtk.StackSwitcher ();


### PR DESCRIPTION
The crossfade doesn't hide the resizing that happens due to the homogeneous setting. Explicitly setting the transition to `NONE` makes it hide instantly before resizing.