### PR TITLE
AppCenterView: hard code elementary OS

### DIFF
--- a/src/Views/AppCenterView.vala
+++ b/src/Views/AppCenterView.vala
@@ -18,7 +18,7 @@
 public class Onboarding.AppCenterView : AbstractOnboardingView {
     public AppCenterView () {
         Object (
-            description: _("Get the apps you need on AppCenter. Curated apps are made for %s and reviewed by elementary.").printf (Utils.os_name),
+            description: _("Get the apps you need on AppCenter. Curated apps are made for elementary OS and reviewed by elementary.").printf (Utils.os_name),
             icon_name: "system-software-install",
             title: _("Get Some Apps")
         );

--- a/src/Views/AppCenterView.vala
+++ b/src/Views/AppCenterView.vala
@@ -18,7 +18,7 @@
 public class Onboarding.AppCenterView : AbstractOnboardingView {
     public AppCenterView () {
         Object (
-            description: _("Get the apps you need on AppCenter. Curated apps are made for elementary OS and reviewed by elementary.").printf (Utils.os_name),
+            description: _("Get the apps you need on AppCenter. Curated apps are made for elementary OS and reviewed by elementary."),
             icon_name: "system-software-install",
             title: _("Get Some Apps")
         );


### PR DESCRIPTION
I think in this context it doesn't make sense to grab the OS name because elementary would never review apps for another OS