### PR TITLE
Make Skip go to Finish page

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -131,19 +131,15 @@ public class Onboarding.MainWindow : Gtk.Window {
                 case "appcenter":
                     stack.visible_child_name = "finish";
                 case "finish":
-                    finish ();
+                    Onboarding.App.settings.set_boolean ("first-run", false);
+                    destroy ();
                     break;
             }
         });
 
         skip_button.clicked.connect (() => {
-            finish ();
+            stack.visible_child_name = "finish";
         });
-    }
-
-    private void finish () {
-        Onboarding.App.settings.set_boolean ("first-run", false);
-        destroy ();
     }
 }
 


### PR DESCRIPTION
As discussed in Slack. Gives a chance for undo, and prevents the case where someone thinks it's a back button and then doesn't know what just happened.