### PR TITLE
Install a desktop to share/applications

### DIFF
--- a/data/autostart.desktop
+++ b/data/autostart.desktop
@@ -5,6 +5,4 @@ Exec=io.elementary.onboarding
 Icon=system-os-installer
 Terminal=false
 Type=Application
-StartupNotify=true
-NoDisplay=true
 Categories=GNOME;GTK;System;

--- a/data/meson.build
+++ b/data/meson.build
@@ -3,8 +3,14 @@ i18n.merge_file(
     output: meson.project_name() + '.desktop',
     po_dir: join_paths(meson.source_root (), 'po', 'extra'),
     type: 'desktop',
-    install_dir: join_paths(get_option('sysconfdir'), 'xdg', 'autostart'),
-    install: true
+    install: true,
+    install_dir: join_paths(get_option('datadir'), 'applications')
+)
+
+install_data(
+    'autostart.desktop',
+    rename: meson.project_name() + '.desktop',
+    install_dir: join_paths(get_option('sysconfdir'), 'xdg', 'autostart')
 )
 
 i18n.merge_file(


### PR DESCRIPTION
Fixes #31 

Creates a new autostart desktop and installs the regular one to share/applications