### PR TITLE
Show new pages on update

### DIFF
--- a/data/io.elementary.onboarding.gschema.xml
+++ b/data/io.elementary.onboarding.gschema.xml
@@ -3,7 +3,11 @@
     <schema path="/io/elementary/onboarding/" id="io.elementary.onboarding">
         <key type="b" name="first-run">
             <default>true</default>
-            <summary>If this app should run at startup.</summary>
+            <summary>True if this app has never been run, for example on a brand new user account.</summary>
+        </key>
+        <key type="as" name="viewed">
+            <default>[]</default>
+            <summary>Screens that have already been viewed. If there are major updates, new screens may be added and will be shown to the user unless they are noted here.</summary>
         </key>
     </schema>
 </schemalist>

--- a/data/io.elementary.onboarding.gschema.xml
+++ b/data/io.elementary.onboarding.gschema.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
     <schema path="/io/elementary/onboarding/" id="io.elementary.onboarding">
-        <key type="b" name="first-run">
-            <default>true</default>
-            <summary>True if this app has never been run, for example on a brand new user account.</summary>
-        </key>
         <key type="as" name="viewed">
             <default>[]</default>
             <summary>Screens that have already been viewed. If there are major updates, new screens may be added and will be shown to the user unless they are noted here.</summary>
         </key>
     </schema>
 </schemalist>
+

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -7,4 +7,5 @@ src/Views/FinishView.vala
 src/Views/HouseKeepingView.vala
 src/Views/LocationServicesView.vala
 src/Views/NightLightView.vala
+src/Views/UpdateView.vala
 src/Views/WelcomeView.vala

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -28,14 +28,7 @@ public class Onboarding.App : Gtk.Application {
     }
 
     public override void activate () {
-        bool is_terminal = Posix.isatty (Posix.STDIN_FILENO);
-
-        var uid = Posix.getuid ();
-        if (uid < MIN_UID)
-            quit ();
-
-        settings = new GLib.Settings ("io.elementary.onboarding");
-        if (!is_terminal && !settings.get_boolean ("first-run")) {
+        if (Posix.getuid () < MIN_UID) {
             quit ();
         }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -19,8 +19,6 @@
  */
 
 public class Onboarding.App : Gtk.Application {
-    public static GLib.Settings settings;
-
     construct {
         application_id = "io.elementary.installer";
         flags = ApplicationFlags.FLAGS_NONE;
@@ -28,8 +26,6 @@ public class Onboarding.App : Gtk.Application {
     }
 
     public override void activate () {
-        settings = new GLib.Settings ("io.elementary.onboarding");
-
         if (Posix.getuid () < MIN_UID) {
             quit ();
         }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -27,16 +27,6 @@ public class Onboarding.App : Gtk.Application {
         Intl.setlocale (LocaleCategory.ALL, "");
     }
 
-    public static Onboarding.App _instance = null;
-    public static Onboarding.App instance {
-        get {
-            if (_instance == null) {
-                _instance = new Onboarding.App ();
-            }
-            return _instance;
-        }
-    }
-
     public override void activate () {
         bool is_terminal = Posix.isatty (Posix.STDIN_FILENO);
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -27,6 +27,16 @@ public class Onboarding.App : Gtk.Application {
         Intl.setlocale (LocaleCategory.ALL, "");
     }
 
+    public static Onboarding.App _instance = null;
+    public static Onboarding.App instance {
+        get {
+            if (_instance == null) {
+                _instance = new Onboarding.App ();
+            }
+            return _instance;
+        }
+    }
+
     public override void activate () {
         bool is_terminal = Posix.isatty (Posix.STDIN_FILENO);
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -28,6 +28,8 @@ public class Onboarding.App : Gtk.Application {
     }
 
     public override void activate () {
+        settings = new GLib.Settings ("io.elementary.onboarding");
+
         if (Posix.getuid () < MIN_UID) {
             quit ();
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -40,14 +40,14 @@ public class Onboarding.MainWindow : Gtk.Window {
 
         viewed = settings.get_strv ("viewed");
 
-        if (settings.get_boolean ("first-run")) {
-            var welcome_view = new WelcomeView ();
-            stack.add_titled (welcome_view, "welcome", welcome_view.title);
-            stack.child_set_property (welcome_view, "icon-name", "pager-checked-symbolic");
-        } else {
+        if ("finish" in viewed) {
             var update_view = new UpdateView ();
             stack.add_titled (update_view, "update", update_view.title);
             stack.child_set_property (update_view, "icon-name", "pager-checked-symbolic");
+        } else {
+            var welcome_view = new WelcomeView ();
+            stack.add_titled (welcome_view, "welcome", welcome_view.title);
+            stack.child_set_property (welcome_view, "icon-name", "pager-checked-symbolic");
         }
 
         var location_services_view = new LocationServicesView ();
@@ -152,7 +152,6 @@ public class Onboarding.MainWindow : Gtk.Window {
             if (index < current_views.length () - 1) {
                 stack.visible_child = current_views.nth_data (index + 1);
             } else {
-                settings.set_boolean ("first-run", false);
                 destroy ();
             }
         });

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -144,10 +144,10 @@ public class Onboarding.MainWindow : Gtk.Window {
         });
 
         next_button.clicked.connect (() => {
-            // GLib.List<unowned Gtk.Widget> views = stack.get_children ();
-            var index = views.index (stack.visible_child);
-            if (index < views.length () - 1) {
-                stack.visible_child = views.nth_data (index + 1);
+            GLib.List<unowned Gtk.Widget> current_views = stack.get_children ();
+            var index = current_views.index (stack.visible_child);
+            if (index < current_views.length () - 1) {
+                stack.visible_child = current_views.nth_data (index + 1);
                 mark_viewed (stack.visible_child_name);
             } else {
                 Onboarding.App.settings.set_boolean ("first-run", false);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -157,7 +157,7 @@ public class Onboarding.MainWindow : Gtk.Window {
     }
 
     private void mark_viewed (string view_name) {
-        if (!(name in viewed)) {
+        if (!(view_name in viewed)) {
             var viewed_copy = viewed;
             viewed_copy += view_name;
             viewed = viewed_copy;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -80,8 +80,7 @@ public class Onboarding.MainWindow : Gtk.Window {
 
         // Bail if there are no feature views
         if (stack.get_children ().length () < 2) {
-            // FIXME: Okay, this isn't quitting…
-            Onboarding.App.instance.quit ();
+            GLib.Application.get_default ().quit ();
         }
 
         var finish_view = new FinishView ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -19,6 +19,7 @@
 
 public class Onboarding.MainWindow : Gtk.Window {
     public string[] viewed { get; set; }
+    private static GLib.Settings settings;
 
     public MainWindow () {
         Object (
@@ -30,14 +31,16 @@ public class Onboarding.MainWindow : Gtk.Window {
     }
 
     construct {
+        settings = new GLib.Settings ("io.elementary.onboarding");
+
         var stack = new Gtk.Stack ();
         stack.expand = true;
         stack.valign = stack.halign = Gtk.Align.CENTER;
         stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
 
-        viewed = Onboarding.App.settings.get_strv ("viewed");
+        viewed = settings.get_strv ("viewed");
 
-        if (Onboarding.App.settings.get_boolean ("first-run")) {
+        if (settings.get_boolean ("first-run")) {
             var welcome_view = new WelcomeView ();
             stack.add_titled (welcome_view, "welcome", welcome_view.title);
             stack.child_set_property (welcome_view, "icon-name", "pager-checked-symbolic");
@@ -148,7 +151,7 @@ public class Onboarding.MainWindow : Gtk.Window {
                 stack.visible_child = current_views.nth_data (index + 1);
                 mark_viewed (stack.visible_child_name);
             } else {
-                Onboarding.App.settings.set_boolean ("first-run", false);
+                settings.set_boolean ("first-run", false);
                 destroy ();
             }
         });
@@ -164,7 +167,7 @@ public class Onboarding.MainWindow : Gtk.Window {
             viewed_copy += view_name;
             viewed = viewed_copy;
 
-            Onboarding.App.settings.set_strv ("viewed", viewed);
+            settings.set_strv ("viewed", viewed);
         }
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -30,9 +30,11 @@ public class Onboarding.MainWindow : Gtk.Window {
         );
     }
 
-    construct {
+    static construct {
         settings = new GLib.Settings ("io.elementary.onboarding");
+    }
 
+    construct {
         var stack = new Gtk.Stack ();
         stack.expand = true;
         stack.valign = stack.halign = Gtk.Align.CENTER;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -53,20 +53,20 @@ public class Onboarding.MainWindow : Gtk.Window {
             stack.child_set_property (update_view, "icon-name", "pager-checked-symbolic");
         }
 
-        var location_services_view = new LocationServicesView ();
         if (!("location" in viewed)) {
+            var location_services_view = new LocationServicesView ();
             stack.add_titled (location_services_view, "location", location_services_view.title);
             stack.child_set_property (location_services_view, "icon-name", "pager-checked-symbolic");
         }
 
-        var night_light_view = new NightLightView ();
         if (!("night-light" in viewed)) {
+            var night_light_view = new NightLightView ();
             stack.add_titled (night_light_view, "night-light", night_light_view.title);
             stack.child_set_property (night_light_view, "icon-name", "pager-checked-symbolic");
         }
 
-        var housekeeping_view = new HouseKeepingView ();
         if (!("housekeeping" in viewed)) {
+            var housekeeping_view = new HouseKeepingView ();
             stack.add_titled (housekeeping_view, "housekeeping", housekeeping_view.title);
             stack.child_set_property (housekeeping_view, "icon-name", "pager-checked-symbolic");
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -30,6 +30,12 @@ public class Onboarding.MainWindow : Gtk.Window {
     }
 
     construct {
+        const string[] FEATURE_VIEWS = {
+            "location",
+            "night-light",
+            "housekeeping"
+        };
+
         var stack = new Gtk.Stack ();
         stack.expand = true;
         stack.valign = stack.halign = Gtk.Align.CENTER;
@@ -39,7 +45,7 @@ public class Onboarding.MainWindow : Gtk.Window {
 
         var welcome_view = new WelcomeView ();
         var update_view = new UpdateView ();
-        if (!strv_contains (viewed, "welcome")) {
+        if (!("welcome" in viewed)) {
             stack.add_titled (welcome_view, "welcome", welcome_view.title);
             stack.child_set_property (welcome_view, "icon-name", "pager-checked-symbolic");
         } else {
@@ -48,26 +54,26 @@ public class Onboarding.MainWindow : Gtk.Window {
         }
 
         var location_services_view = new LocationServicesView ();
-        if (!strv_contains (viewed, "location")) {
+        if (!("location" in viewed)) {
             stack.add_titled (location_services_view, "location", location_services_view.title);
             stack.child_set_property (location_services_view, "icon-name", "pager-checked-symbolic");
         }
 
         var night_light_view = new NightLightView ();
-        if (!strv_contains (viewed, "night-light")) {
+        if (!("night-light" in viewed)) {
             stack.add_titled (night_light_view, "night-light", night_light_view.title);
             stack.child_set_property (night_light_view, "icon-name", "pager-checked-symbolic");
         }
 
         var housekeeping_view = new HouseKeepingView ();
-        if (!strv_contains (viewed, "housekeeping")) {
+        if (!("housekeeping" in viewed)) {
             stack.add_titled (housekeeping_view, "housekeeping", housekeeping_view.title);
             stack.child_set_property (housekeeping_view, "icon-name", "pager-checked-symbolic");
         }
 
         AppCenterView? appcenter_view = null;
         if (
-            !strv_contains (viewed, "appcenter") &&
+            !("appcenter" in viewed) &&
             Environment.find_program_in_path ("io.elementary.appcenter") != null
         ) {
             appcenter_view = new AppCenterView ();
@@ -179,4 +185,3 @@ public class Onboarding.MainWindow : Gtk.Window {
         }
     }
 }
-

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -18,6 +18,8 @@
  */
 
 public class Onboarding.MainWindow : Gtk.Window {
+    public string[] viewed { get; set; }
+
     public MainWindow () {
         Object (
             deletable: false,
@@ -33,15 +35,16 @@ public class Onboarding.MainWindow : Gtk.Window {
         stack.valign = stack.halign = Gtk.Align.CENTER;
         stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
 
-        var viewed = Onboarding.App.settings.get_strv ("viewed");
+        viewed = Onboarding.App.settings.get_strv ("viewed");
 
         var welcome_view = new WelcomeView ();
-        var update_view = new WelcomeView ();
+        var update_view = new UpdateView ();
         if (!strv_contains (viewed, "welcome")) {
             stack.add_titled (welcome_view, "welcome", welcome_view.title);
             stack.child_set_property (welcome_view, "icon-name", "pager-checked-symbolic");
         } else {
-            
+            stack.add_titled (update_view, "update", update_view.title);
+            stack.child_set_property (update_view, "icon-name", "pager-checked-symbolic");
         }
 
         var location_services_view = new LocationServicesView ();
@@ -134,18 +137,25 @@ public class Onboarding.MainWindow : Gtk.Window {
         next_button.clicked.connect (() => {
             switch (stack.visible_child_name) {
                 case "welcome":
+                    mark_viewed ("welcome");
+                    stack.visible_child_name = "location";
+                case "update":
                     stack.visible_child_name = "location";
                 case "location":
+                    mark_viewed ("location");
                     stack.visible_child_name = "night-light";
                 case "night-light":
+                    mark_viewed ("night-light");
                     stack.visible_child_name = "housekeeping";
                 case "housekeeping":
+                    mark_viewed ("housekeeping");
                     if (appcenter_view != null) {
                         stack.visible_child_name = "appcenter";
                     } else {
                         stack.visible_child_name = "finish";
                     }
                 case "appcenter":
+                    mark_viewed ("appcenter");
                     stack.visible_child_name = "finish";
                 case "finish":
                     Onboarding.App.settings.set_boolean ("first-run", false);
@@ -157,6 +167,16 @@ public class Onboarding.MainWindow : Gtk.Window {
         skip_button.clicked.connect (() => {
             stack.visible_child_name = "finish";
         });
+    }
+
+    private void mark_viewed (string name) {
+        if (!(name in viewed)) {
+            var viewed_copy = viewed;
+            viewed_copy += name;
+            viewed = viewed_copy;
+
+            Onboarding.App.settings.set_strv ("viewed", viewed);
+        }
     }
 }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -33,24 +33,40 @@ public class Onboarding.MainWindow : Gtk.Window {
         stack.valign = stack.halign = Gtk.Align.CENTER;
         stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
 
+        var viewed = Onboarding.App.settings.get_strv ("viewed");
+
         var welcome_view = new WelcomeView ();
-        stack.add_titled (welcome_view, "welcome", welcome_view.title);
-        stack.child_set_property (welcome_view, "icon-name", "pager-checked-symbolic");
+        var update_view = new WelcomeView ();
+        if (!strv_contains (viewed, "welcome")) {
+            stack.add_titled (welcome_view, "welcome", welcome_view.title);
+            stack.child_set_property (welcome_view, "icon-name", "pager-checked-symbolic");
+        } else {
+            
+        }
 
         var location_services_view = new LocationServicesView ();
-        stack.add_titled (location_services_view, "location", location_services_view.title);
-        stack.child_set_property (location_services_view, "icon-name", "pager-checked-symbolic");
+        if (!strv_contains (viewed, "location")) {
+            stack.add_titled (location_services_view, "location", location_services_view.title);
+            stack.child_set_property (location_services_view, "icon-name", "pager-checked-symbolic");
+        }
 
         var night_light_view = new NightLightView ();
-        stack.add_titled (night_light_view, "night-light", night_light_view.title);
-        stack.child_set_property (night_light_view, "icon-name", "pager-checked-symbolic");
+        if (!strv_contains (viewed, "night-light")) {
+            stack.add_titled (night_light_view, "night-light", night_light_view.title);
+            stack.child_set_property (night_light_view, "icon-name", "pager-checked-symbolic");
+        }
 
         var housekeeping_view = new HouseKeepingView ();
-        stack.add_titled (housekeeping_view, "housekeeping", housekeeping_view.title);
-        stack.child_set_property (housekeeping_view, "icon-name", "pager-checked-symbolic");
+        if (!strv_contains (viewed, "housekeeping")) {
+            stack.add_titled (housekeeping_view, "housekeeping", housekeeping_view.title);
+            stack.child_set_property (housekeeping_view, "icon-name", "pager-checked-symbolic");
+        }
 
         AppCenterView? appcenter_view = null;
-        if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
+        if (
+            !strv_contains (viewed, "appcenter") &&
+            Environment.find_program_in_path ("io.elementary.appcenter") != null
+        ) {
             appcenter_view = new AppCenterView ();
             stack.add_titled (appcenter_view, "appcenter", appcenter_view.title);
             stack.child_set_property (appcenter_view, "icon-name", "pager-checked-symbolic");
@@ -114,6 +130,7 @@ public class Onboarding.MainWindow : Gtk.Window {
             }
         });
 
+        // TODO: automate this with `get_children` and `@foreach`
         next_button.clicked.connect (() => {
             switch (stack.visible_child_name) {
                 case "welcome":

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -159,6 +159,15 @@ public class Onboarding.MainWindow : Gtk.Window {
         });
 
         skip_button.clicked.connect (() => {
+            foreach (Gtk.Widget view in views) {
+            var view_name_value = GLib.Value (typeof (string));
+            stack.child_get_property (view, "name", ref view_name_value);
+
+            string view_name = view_name_value.get_string ();
+
+            mark_viewed (view_name);
+        }
+
             stack.visible_child_name = "finish";
         });
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -33,7 +33,8 @@ public class Onboarding.MainWindow : Gtk.Window {
         const string[] FEATURE_VIEWS = {
             "location",
             "night-light",
-            "housekeeping"
+            "housekeeping",
+            "appcenter"
         };
 
         var stack = new Gtk.Stack ();
@@ -53,32 +54,29 @@ public class Onboarding.MainWindow : Gtk.Window {
             stack.child_set_property (update_view, "icon-name", "pager-checked-symbolic");
         }
 
-        if (!("location" in viewed)) {
-            var location_services_view = new LocationServicesView ();
-            stack.add_titled (location_services_view, "location", location_services_view.title);
-            stack.child_set_property (location_services_view, "icon-name", "pager-checked-symbolic");
-        }
+        var location_services_view = new LocationServicesView ();
+        stack.add_titled (location_services_view, "location", location_services_view.title);
+        stack.child_set_property (location_services_view, "icon-name", "pager-checked-symbolic");
 
-        if (!("night-light" in viewed)) {
-            var night_light_view = new NightLightView ();
-            stack.add_titled (night_light_view, "night-light", night_light_view.title);
-            stack.child_set_property (night_light_view, "icon-name", "pager-checked-symbolic");
-        }
+        var night_light_view = new NightLightView ();
+        stack.add_titled (night_light_view, "night-light", night_light_view.title);
+        stack.child_set_property (night_light_view, "icon-name", "pager-checked-symbolic");
 
-        if (!("housekeeping" in viewed)) {
-            var housekeeping_view = new HouseKeepingView ();
-            stack.add_titled (housekeeping_view, "housekeeping", housekeeping_view.title);
-            stack.child_set_property (housekeeping_view, "icon-name", "pager-checked-symbolic");
-        }
+        var housekeeping_view = new HouseKeepingView ();
+        stack.add_titled (housekeeping_view, "housekeeping", housekeeping_view.title);
+        stack.child_set_property (housekeeping_view, "icon-name", "pager-checked-symbolic");
 
         AppCenterView? appcenter_view = null;
-        if (
-            !("appcenter" in viewed) &&
-            Environment.find_program_in_path ("io.elementary.appcenter") != null
-        ) {
+        if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
             appcenter_view = new AppCenterView ();
             stack.add_titled (appcenter_view, "appcenter", appcenter_view.title);
             stack.child_set_property (appcenter_view, "icon-name", "pager-checked-symbolic");
+        }
+
+        foreach (string view_name in FEATURE_VIEWS) {
+            if (view_name in viewed) {
+                stack.get_child_by_name (view_name).destroy ();
+            }
         }
 
         var finish_view = new FinishView ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -160,13 +160,13 @@ public class Onboarding.MainWindow : Gtk.Window {
 
         skip_button.clicked.connect (() => {
             foreach (Gtk.Widget view in views) {
-            var view_name_value = GLib.Value (typeof (string));
-            stack.child_get_property (view, "name", ref view_name_value);
+                var view_name_value = GLib.Value (typeof (string));
+                stack.child_get_property (view, "name", ref view_name_value);
 
-            string view_name = view_name_value.get_string ();
+                string view_name = view_name_value.get_string ();
 
-            mark_viewed (view_name);
-        }
+                mark_viewed (view_name);
+            }
 
             stack.visible_child_name = "finish";
         });

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -30,12 +30,12 @@ public class Onboarding.MainWindow : Gtk.Window {
     }
 
     construct {
-        const string[] FEATURE_VIEWS = {
-            "location",
-            "night-light",
-            "housekeeping",
-            "appcenter"
-        };
+        // const string[] FEATURE_VIEWS = {
+        //     "location",
+        //     "night-light",
+        //     "housekeeping",
+        //     "appcenter"
+        // };
 
         var stack = new Gtk.Stack ();
         stack.expand = true;
@@ -73,7 +73,13 @@ public class Onboarding.MainWindow : Gtk.Window {
             stack.child_set_property (appcenter_view, "icon-name", "pager-checked-symbolic");
         }
 
-        foreach (string view_name in FEATURE_VIEWS) {
+        GLib.List<unowned Gtk.Widget> views = stack.get_children ();
+        foreach (Gtk.Widget view in views) {
+            var view_name_value = GLib.Value (typeof (string));
+            stack.child_get_property (view, "name", ref view_name_value);
+
+            string view_name = view_name_value.get_string ();
+
             if (view_name in viewed) {
                 stack.get_child_by_name (view_name).destroy ();
             }
@@ -138,7 +144,7 @@ public class Onboarding.MainWindow : Gtk.Window {
         });
 
         next_button.clicked.connect (() => {
-            GLib.List<unowned Gtk.Widget> views = stack.get_children ();
+            // GLib.List<unowned Gtk.Widget> views = stack.get_children ();
             var index = views.index (stack.visible_child);
             if (index < views.length () - 1) {
                 stack.visible_child = views.nth_data (index + 1);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -66,7 +66,6 @@ public class Onboarding.MainWindow : Gtk.Window {
             stack.child_set_property (appcenter_view, "icon-name", "pager-checked-symbolic");
         }
 
-        int view_index = 0;
         GLib.List<unowned Gtk.Widget> views = stack.get_children ();
         foreach (Gtk.Widget view in views) {
             var view_name_value = GLib.Value (typeof (string));

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -43,12 +43,12 @@ public class Onboarding.MainWindow : Gtk.Window {
 
         viewed = Onboarding.App.settings.get_strv ("viewed");
 
-        var welcome_view = new WelcomeView ();
-        var update_view = new UpdateView ();
-        if (!("welcome" in viewed)) {
+        if (Onboarding.App.settings.get_boolean ("first-run")) {
+            var welcome_view = new WelcomeView ();
             stack.add_titled (welcome_view, "welcome", welcome_view.title);
             stack.child_set_property (welcome_view, "icon-name", "pager-checked-symbolic");
         } else {
+            var update_view = new UpdateView ();
             stack.add_titled (update_view, "update", update_view.title);
             stack.child_set_property (update_view, "icon-name", "pager-checked-symbolic");
         }
@@ -175,10 +175,10 @@ public class Onboarding.MainWindow : Gtk.Window {
         });
     }
 
-    private void mark_viewed (string name) {
+    private void mark_viewed (string view_name) {
         if (!(name in viewed)) {
             var viewed_copy = viewed;
-            viewed_copy += name;
+            viewed_copy += view_name;
             viewed = viewed_copy;
 
             Onboarding.App.settings.set_strv ("viewed", viewed);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -135,6 +135,8 @@ public class Onboarding.MainWindow : Gtk.Window {
         next_button.grab_focus ();
 
         stack.notify["visible-child-name"].connect (() => {
+            mark_viewed (stack.visible_child_name);
+
             if (stack.visible_child_name == "finish") {
                 next_button.label = _("Get Started");
                 skip_revealer.reveal_child = false;
@@ -149,7 +151,6 @@ public class Onboarding.MainWindow : Gtk.Window {
             var index = current_views.index (stack.visible_child);
             if (index < current_views.length () - 1) {
                 stack.visible_child = current_views.nth_data (index + 1);
-                mark_viewed (stack.visible_child_name);
             } else {
                 settings.set_boolean ("first-run", false);
                 destroy ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -30,13 +30,6 @@ public class Onboarding.MainWindow : Gtk.Window {
     }
 
     construct {
-        // const string[] FEATURE_VIEWS = {
-        //     "location",
-        //     "night-light",
-        //     "housekeeping",
-        //     "appcenter"
-        // };
-
         var stack = new Gtk.Stack ();
         stack.expand = true;
         stack.valign = stack.halign = Gtk.Align.CENTER;
@@ -73,6 +66,7 @@ public class Onboarding.MainWindow : Gtk.Window {
             stack.child_set_property (appcenter_view, "icon-name", "pager-checked-symbolic");
         }
 
+        int view_index = 0;
         GLib.List<unowned Gtk.Widget> views = stack.get_children ();
         foreach (Gtk.Widget view in views) {
             var view_name_value = GLib.Value (typeof (string));
@@ -81,8 +75,14 @@ public class Onboarding.MainWindow : Gtk.Window {
             string view_name = view_name_value.get_string ();
 
             if (view_name in viewed) {
-                stack.get_child_by_name (view_name).destroy ();
+                view.destroy ();
             }
+        }
+
+        // Bail if there are no feature views
+        if (stack.get_children ().length () < 2) {
+            // FIXME: Okay, this isn't quitting…
+            Onboarding.App.instance.quit ();
         }
 
         var finish_view = new FinishView ();

--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -36,6 +36,7 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
         description_label.justify = Gtk.Justification.CENTER;
         description_label.wrap = true;
         description_label.max_width_chars = 50;
+        description_label.use_markup = true;
 
         var header_area = new Gtk.Grid ();
         header_area.column_spacing = 12;

--- a/src/Views/UpdateView.vala
+++ b/src/Views/UpdateView.vala
@@ -1,0 +1,77 @@
+/*-
+ * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+public class Onboarding.UpdateView : AbstractOnboardingView {
+    public UpdateView () {
+        Object (
+            description: _("Continue to set up some useful new features. Visit the links below for more information about %s.").printf (Utils.os_name),
+            icon_name: "distributor-logo",
+            title: _("What’s New")
+        );
+    }
+
+    construct {
+        var thebasics_link = new ImageLinkButton (
+            "https://elementary.io/docs/learning-the-basics#learning-the-basics",
+            _("Basics Guide…"),
+            "text-x-generic-symbolic"
+        );
+
+        var support_link = new ImageLinkButton (
+            Utils.support_url,
+            _("Community Support…"),
+            "help-contents-symbolic"
+        );
+
+        var getinvolved_link = new ImageLinkButton (
+            "https://elementary.io/get-involved",
+            _("Get Involved…"),
+            "applications-development-symbolic"
+        );
+
+        custom_bin.attach (thebasics_link, 0, 0);
+        custom_bin.attach (support_link, 0, 1);
+        custom_bin.attach (getinvolved_link, 0, 2);
+    }
+
+    private class ImageLinkButton : Gtk.LinkButton {
+        public string icon_name { get; construct; }
+        public string label_string { get; construct; }
+
+        public ImageLinkButton (string uri, string label_string, string icon_name) {
+            Object (
+                uri: uri,
+                label_string: label_string,
+                icon_name: icon_name
+            );
+        }
+
+        construct {
+            var image = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.MENU);
+
+            var left_label = new Gtk.Label (label_string);
+            left_label.xalign = 0;
+
+            var grid = new Gtk.Grid ();
+            grid.add (image);
+            grid.add (left_label);
+
+            add (grid);
+        }
+    }
+}
+

--- a/src/Views/UpdateView.vala
+++ b/src/Views/UpdateView.vala
@@ -18,7 +18,7 @@
 public class Onboarding.UpdateView : AbstractOnboardingView {
     public UpdateView () {
         Object (
-            description: _("Continue to set up some useful new features."),
+            description: _("Continue to set up some useful new features. For more detailed information about updates, check out <a href='https://medium.com/elementaryos/tagged/updates'>our blog</a>."),
             icon_name: "system-software-update",
             title: _("What’s New")
         );

--- a/src/Views/UpdateView.vala
+++ b/src/Views/UpdateView.vala
@@ -18,60 +18,10 @@
 public class Onboarding.UpdateView : AbstractOnboardingView {
     public UpdateView () {
         Object (
-            description: _("Continue to set up some useful new features. Visit the links below for more information about %s.").printf (Utils.os_name),
-            icon_name: "distributor-logo",
+            description: _("Continue to set up some useful new features."),
+            icon_name: "system-software-update",
             title: _("What’s New")
         );
-    }
-
-    construct {
-        var thebasics_link = new ImageLinkButton (
-            "https://elementary.io/docs/learning-the-basics#learning-the-basics",
-            _("Basics Guide…"),
-            "text-x-generic-symbolic"
-        );
-
-        var support_link = new ImageLinkButton (
-            Utils.support_url,
-            _("Community Support…"),
-            "help-contents-symbolic"
-        );
-
-        var getinvolved_link = new ImageLinkButton (
-            "https://elementary.io/get-involved",
-            _("Get Involved…"),
-            "applications-development-symbolic"
-        );
-
-        custom_bin.attach (thebasics_link, 0, 0);
-        custom_bin.attach (support_link, 0, 1);
-        custom_bin.attach (getinvolved_link, 0, 2);
-    }
-
-    private class ImageLinkButton : Gtk.LinkButton {
-        public string icon_name { get; construct; }
-        public string label_string { get; construct; }
-
-        public ImageLinkButton (string uri, string label_string, string icon_name) {
-            Object (
-                uri: uri,
-                label_string: label_string,
-                icon_name: icon_name
-            );
-        }
-
-        construct {
-            var image = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.MENU);
-
-            var left_label = new Gtk.Label (label_string);
-            left_label.xalign = 0;
-
-            var grid = new Gtk.Grid ();
-            grid.add (image);
-            grid.add (left_label);
-
-            add (grid);
-        }
     }
 }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,7 +9,8 @@ vala_files = [
     'Views/HouseKeepingView.vala',
     'Views/LocationServicesView.vala',
     'Views/NightLightView.vala',
-    'Views/WelcomeView.vala'
+    'Views/UpdateView.vala',
+    'Views/WelcomeView.vala',
 ]
 
 executable(meson.project_name(), vala_files,


### PR DESCRIPTION
Based on something @danrabbit had mentioned. Basically, this would allow us to use onboarding to introduce new major features for existing installs by tracking which pages have been seen.

- [x] Track which views have been viewed
- [x] …even when using the pagers
- [x] Skip already-viewed views
- [x] Create a new "udpate" view to show after first-run
- [x] Don't always quit after first-run
- [x] Quit if there are no feature views to show
- [x] Mark children as viewed when skipping all
- [ ] …?