### PR TITLE
Do not show onboarding on Guest sessions

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('min_uid', type : 'integer', value : 1000, description: 'Minimum user id that normal users can have (UID_MIN in /etc/login.defs)')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -30,6 +30,10 @@ public class Onboarding.App : Gtk.Application {
     public override void activate () {
         bool is_terminal = Posix.isatty (Posix.STDIN_FILENO);
 
+        var uid = Posix.getuid ();
+        if (uid < MIN_UID)
+            quit ();
+
         settings = new GLib.Settings ("io.elementary.onboarding");
         if (!is_terminal && !settings.get_boolean ("first-run")) {
             quit ();

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -1,0 +1,3 @@
+namespace Onboarding {
+    public const int MIN_UID = @MIN_UID@;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,19 @@ vala_files = [
     'Views/WelcomeView.vala'
 ]
 
-executable(meson.project_name(), vala_files,
-           asresources,
-           dependencies : dependencies,
-           install: true)
+config_data = configuration_data()
+config_data.set('MIN_UID', get_option('min_uid'))
+config_file = configure_file(
+  input: 'config.vala.in',
+  output: 'config.vala',
+  configuration: config_data
+)
+
+executable(
+    meson.project_name(),
+    vala_files,
+    asresources,
+    config_file,
+    dependencies : dependencies,
+    install: true
+)


### PR DESCRIPTION
With a meson_options.txt as I can already hear Fedora and ArchLinux people screaming
Fixes https://github.com/elementary/default-settings/issues/117