### PR TITLE
Check for GeoClue key before creating Location Services view

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -18,6 +18,7 @@
  */
 
 public class Onboarding.MainWindow : Gtk.Window {
+    public const string GEOCLUE_SCHEMA = "io.elementary.desktop.agent-geoclue2";
     public string[] viewed { get; set; }
     private static GLib.Settings settings;
 
@@ -52,13 +53,9 @@ public class Onboarding.MainWindow : Gtk.Window {
             stack.child_set_property (welcome_view, "icon-name", "pager-checked-symbolic");
         }
 
-        const string GEOCLUE_SCHEMA = "io.elementary.desktop.agent-geoclue2";
-
         var lookup = SettingsSchemaSource.get_default ().lookup (GEOCLUE_SCHEMA, false);
-
-        LocationServicesView? location_services_view = null;
         if (lookup != null) {
-            location_services_view = new LocationServicesView ();
+            var location_services_view = new LocationServicesView ();
             stack.add_titled (location_services_view, "location", location_services_view.title);
             stack.child_set_property (location_services_view, "icon-name", "pager-checked-symbolic");
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -52,9 +52,17 @@ public class Onboarding.MainWindow : Gtk.Window {
             stack.child_set_property (welcome_view, "icon-name", "pager-checked-symbolic");
         }
 
-        var location_services_view = new LocationServicesView ();
-        stack.add_titled (location_services_view, "location", location_services_view.title);
-        stack.child_set_property (location_services_view, "icon-name", "pager-checked-symbolic");
+        const string GEOCLUE_SCHEMA = "io.elementary.desktop.agent-geoclue2";
+
+
+        var lookup = SettingsSchemaSource.get_default ().lookup (GEOCLUE_SCHEMA, false);
+
+        LocationServicesView? location_services_view = null;
+        if (lookup != null) {
+            location_services_view = new LocationServicesView ();
+            stack.add_titled (location_services_view, "location", location_services_view.title);
+            stack.child_set_property (location_services_view, "icon-name", "pager-checked-symbolic");
+        }
 
         var night_light_view = new NightLightView ();
         stack.add_titled (night_light_view, "night-light", night_light_view.title);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -54,7 +54,6 @@ public class Onboarding.MainWindow : Gtk.Window {
 
         const string GEOCLUE_SCHEMA = "io.elementary.desktop.agent-geoclue2";
 
-
         var lookup = SettingsSchemaSource.get_default ().lookup (GEOCLUE_SCHEMA, false);
 
         LocationServicesView? location_services_view = null;

--- a/src/Views/LocationServicesView.vala
+++ b/src/Views/LocationServicesView.vala
@@ -29,7 +29,7 @@ public class Onboarding.LocationServicesView : AbstractOnboardingView {
 
         var service_switch = new Gtk.Switch ();
 
-        var settings = new GLib.Settings ("io.elementary.desktop.agent-geoclue2");
+        var settings = new GLib.Settings (Onboarding.MainWindow.GEOCLUE_SCHEMA);
         settings.bind ("location-enabled", service_switch, "active", GLib.SettingsBindFlags.DEFAULT);
 
         custom_bin.add (switch_label);


### PR DESCRIPTION
Fixes #53. You can test by making sure the GeoClue agent is uninstalled, i.e.

```
sudo apt purge pantheon-agent-geoclue2
```

And make sure all views should show up:

```
gsettings reset io.elementary.onboarding viewed
```

…then run Onboarding and see that the Location Services view doesn't show up. Don't forget to reinstall the GeoClue agent for yourself. :)