### PR TITLE
No need for a null AppCenter view

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -68,9 +68,8 @@ public class Onboarding.MainWindow : Gtk.Window {
         stack.add_titled (housekeeping_view, "housekeeping", housekeeping_view.title);
         stack.child_set_property (housekeeping_view, "icon-name", "pager-checked-symbolic");
 
-        AppCenterView? appcenter_view = null;
         if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
-            appcenter_view = new AppCenterView ();
+            var appcenter_view = new AppCenterView ();
             stack.add_titled (appcenter_view, "appcenter", appcenter_view.title);
             stack.child_set_property (appcenter_view, "icon-name", "pager-checked-symbolic");
         }


### PR DESCRIPTION
Was an artifact of the old way we built the views.