### PR TITLE
Get OS logo from os-release

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -41,6 +41,18 @@ public class Utils {
         }
     }
 
+    private static string _logo_icon_name;
+    public static string logo_icon_name {
+        get {
+            if (_logo_icon_name == null) {
+                parse_osrelease ();
+            }
+
+            return _logo_icon_name;
+        }
+    }
+
+
     private static void parse_osrelease () {
         var file = File.new_for_path ("/etc/os-release");
         try {
@@ -56,10 +68,12 @@ public class Utils {
             }
             _os_name = osrel["NAME"];
             _support_url = osrel["SUPPORT_URL"];
+            _logo_icon_name = osrel["LOGO"];
         } catch (Error e) {
             critical (e.message);
             _os_name = "elementary OS";
             _support_url = "https://elementary.io/support";
+            _logo_icon_name = "distributor-logo";
         }
     }
 }

--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -19,7 +19,7 @@ public class Onboarding.WelcomeView : AbstractOnboardingView {
     public WelcomeView () {
         Object (
             description: _("Continue to set up some useful features. Visit the links below for more information about %s.").printf (Utils.os_name),
-            icon_name: "distributor-logo",
+            icon_name: Utils.logo_icon_name,
             title: _("Welcome to %s!").printf (Utils.os_name)
         );
     }


### PR DESCRIPTION
Working on the next Pantheon release for NixOS packaging onboarding, I noticed it didn't use our logo.

This fixes that for other downstreams who's icon isn't called "distributor-logo".
![Screenshot from 2019-09-18 17 03 13](https://user-images.githubusercontent.com/28888242/65185909-8373bc00-da36-11e9-9b0a-dc30c342363a.png)
