### PR TITLE
Fallback in logo_icon_name utility method

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -46,6 +46,11 @@ public class Utils {
         get {
             if (_logo_icon_name == null) {
                 parse_osrelease ();
+
+                // If it's still null, fall back
+                if (_logo_icon_name == null) {
+                    _logo_icon_name = "distributor-logo";
+                }
             }
 
             return _logo_icon_name;


### PR DESCRIPTION
Fixes #65. Can be tested by commenting out the `LOGO` line in `/etc/os-release`.