### PR TITLE
Add elementary Sync View

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ gtk_dep = dependency('gtk+-3.0')
 posix_dep = meson.get_compiler('vala').find_library('posix')
 handy_dep = dependency('libhandy-0.0', version: '>=0.0.11')
 m_dep = cc.find_library('m', required : false)
+webkit_dep = dependency('webkit2gtk-4.0')
 
 dependencies = [
     gee_dep,
@@ -32,7 +33,8 @@ dependencies = [
     gtk_dep,
     posix_dep,
     handy_dep,
-    m_dep
+    m_dep,
+    webkit_dep,
 ]
 
 asresources = gnome.compile_resources(

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1,5 +1,5 @@
-/*-
- * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+/*
+ * Copyright © 2019–2020 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,6 +53,7 @@ public class Onboarding.MainWindow : Gtk.Window {
             paginator.add (welcome_view);
         }
 
+        // TODO: Only add if we have Internet
         var sync_view = new SyncView ();
         paginator.add (sync_view);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -153,8 +153,10 @@ public class Onboarding.MainWindow : Gtk.Window {
             if (visible_view == null) {
                 return;
             } else if (visible_view.view_name == "sync") {
+                next_button.label = _("Not Now");
                 next_button.get_style_context ().remove_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             } else {
+                next_button.label = _("Next");
                 next_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -109,9 +109,6 @@ public class Onboarding.MainWindow : Gtk.Window {
         finish_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
         next_finish_overlay.add (finish_button);
 
-        var skip_sync_button = new Gtk.Button.with_label (_("Not Now"));
-        next_finish_overlay.add_overlay (skip_sync_button);
-
         var next_button = new Gtk.Button.with_label (_("Next"));
         next_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
         next_finish_overlay.add_overlay (next_button);
@@ -155,6 +152,10 @@ public class Onboarding.MainWindow : Gtk.Window {
             var visible_view = get_visible_view ();
             if (visible_view == null) {
                 return;
+            } else if (visible_view.view_name == "sync") {
+                next_button.get_style_context ().remove_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+            } else {
+                next_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             }
 
             mark_viewed (visible_view.view_name);
@@ -166,6 +167,8 @@ public class Onboarding.MainWindow : Gtk.Window {
 
             next_button.opacity = opacity;
             next_button.visible = opacity > 0;
+
+            finish_button.opacity = 1 - opacity;
         });
 
         next_button.clicked.connect (() => {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -53,6 +53,9 @@ public class Onboarding.MainWindow : Gtk.Window {
             paginator.add (welcome_view);
         }
 
+        var sync_view = new SyncView ();
+        paginator.add (sync_view);
+
         var lookup = SettingsSchemaSource.get_default ().lookup (GEOCLUE_SCHEMA, false);
         if (lookup != null) {
             var location_services_view = new LocationServicesView ();
@@ -90,12 +93,12 @@ public class Onboarding.MainWindow : Gtk.Window {
         var finish_view = new FinishView ();
         paginator.add (finish_view);
 
-        var skip_button = new Gtk.Button.with_label (_("Skip All"));
+        var skip_all_button = new Gtk.Button.with_label (_("Skip All"));
 
-        var skip_revealer = new Gtk.Revealer ();
-        skip_revealer.reveal_child = true;
-        skip_revealer.transition_type = Gtk.RevealerTransitionType.NONE;
-        skip_revealer.add (skip_button);
+        var skip_all_revealer = new Gtk.Revealer ();
+        skip_all_revealer.reveal_child = true;
+        skip_all_revealer.transition_type = Gtk.RevealerTransitionType.NONE;
+        skip_all_revealer.add (skip_all_button);
 
         var switcher = new Switcher (paginator);
         switcher.halign = Gtk.Align.CENTER;
@@ -106,12 +109,15 @@ public class Onboarding.MainWindow : Gtk.Window {
         finish_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
         next_finish_overlay.add (finish_button);
 
+        var skip_sync_button = new Gtk.Button.with_label (_("Not Now"));
+        next_finish_overlay.add_overlay (skip_sync_button);
+
         var next_button = new Gtk.Button.with_label (_("Next"));
         next_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
         next_finish_overlay.add_overlay (next_button);
 
         buttons_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
-        buttons_group.add_widget (skip_revealer);
+        buttons_group.add_widget (skip_all_revealer);
         buttons_group.add_widget (next_button);
         buttons_group.add_widget (finish_button);
 
@@ -121,7 +127,7 @@ public class Onboarding.MainWindow : Gtk.Window {
         action_area.spacing = 6;
         action_area.valign = Gtk.Align.END;
         action_area.layout_style = Gtk.ButtonBoxStyle.EDGE;
-        action_area.add (skip_revealer);
+        action_area.add (skip_all_revealer);
         action_area.add (switcher);
         action_area.add (next_finish_overlay);
         action_area.set_child_non_homogeneous (switcher, true);
@@ -155,8 +161,8 @@ public class Onboarding.MainWindow : Gtk.Window {
 
             var opacity = double.min (1, paginator.n_pages - paginator.position - 1);
 
-            skip_button.opacity = opacity;
-            skip_revealer.reveal_child = opacity > 0;
+            skip_all_button.opacity = opacity;
+            skip_all_revealer.reveal_child = opacity > 0;
 
             next_button.opacity = opacity;
             next_button.visible = opacity > 0;
@@ -174,7 +180,7 @@ public class Onboarding.MainWindow : Gtk.Window {
             destroy ();
         });
 
-        skip_button.clicked.connect (() => {
+        skip_all_button.clicked.connect (() => {
             foreach (Gtk.Widget view in paginator.get_children ()) {
                 assert (view is AbstractOnboardingView);
 

--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -1,5 +1,5 @@
-/*-
- * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+/*
+ * Copyright © 2019–2020 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,6 +33,7 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
         if (icon_name != null) {
             var image = new Gtk.Image ();
             image.icon_name = icon_name;
+            image.margin_top = 6; // Match the inside of the web view
             image.pixel_size = 64;
 
             var badge = new Gtk.Image ();

--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -90,6 +90,7 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
             header_area.column_spacing = 12;
             header_area.halign = Gtk.Align.CENTER;
             header_area.expand = true;
+            header_area.margin_top = 6; // Give us some breathing room to match this in web views
             header_area.row_spacing = 12;
             header_area.orientation = Gtk.Orientation.VERTICAL;
             header_area.add (overlay);

--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -16,11 +16,13 @@
  */
 
 public abstract class AbstractOnboardingView : Gtk.Grid {
+    private const string OAUTH_URL = "https://flatpak-auth.elementary.io/register";
     public string view_name { get; construct; }
-    public string description { get; set; }
-    public string icon_name { get; construct; }
+    public string? description { get; set; }
+    public string? icon_name { get; construct; }
     public string? badge_name { get; construct; }
     public string title { get; construct; }
+    public string? url { get; construct; }
 
     public Gtk.Grid custom_bin { get; private set; }
 
@@ -50,28 +52,37 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
         description_label.max_width_chars = 50;
         description_label.use_markup = true;
 
-        var header_area = new Gtk.Grid ();
-        header_area.column_spacing = 12;
-        header_area.halign = Gtk.Align.CENTER;
-        header_area.expand = true;
-        header_area.row_spacing = 12;
-        header_area.orientation = Gtk.Orientation.VERTICAL;
-        header_area.add (overlay);
-        header_area.add (title_label);
-        header_area.add (description_label);
-
-        custom_bin = new Gtk.Grid ();
-        custom_bin.column_spacing = 12;
-        custom_bin.expand = true;
-        custom_bin.row_spacing = 6;
-        custom_bin.halign = Gtk.Align.CENTER;
-
         margin_start = margin_end = 10;
         orientation = Gtk.Orientation.VERTICAL;
         row_spacing = 24;
         expand = true;
-        add (header_area);
-        add (custom_bin);
+
+        if (url != null) {
+            var web_view = new WebKit.WebView ();
+            web_view.expand = true;
+            web_view.load_uri (OAUTH_URL);
+
+            add (web_view);
+        } else {
+            var header_area = new Gtk.Grid ();
+            header_area.column_spacing = 12;
+            header_area.halign = Gtk.Align.CENTER;
+            header_area.expand = true;
+            header_area.row_spacing = 12;
+            header_area.orientation = Gtk.Orientation.VERTICAL;
+            header_area.add (overlay);
+            header_area.add (title_label);
+            header_area.add (description_label);
+
+            custom_bin = new Gtk.Grid ();
+            custom_bin.column_spacing = 12;
+            custom_bin.expand = true;
+            custom_bin.row_spacing = 6;
+            custom_bin.halign = Gtk.Align.CENTER;
+
+            add (header_area);
+            add (custom_bin);
+        }
 
         bind_property ("description", description_label, "label");
     }

--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -21,7 +21,6 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
     public string? icon_name { get; construct; }
     public string? badge_name { get; construct; }
     public string title { get; construct; }
-    public string? url { get; construct; }
 
     public Gtk.Grid custom_bin { get; private set; }
 
@@ -31,36 +30,7 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
         row_spacing = 24;
         expand = true;
 
-        if (url != null) {
-            var css = new WebKit.UserStyleSheet (
-                """
-                html,
-                body {
-                    background-color: #f5f5f5;
-                    color: #333;
-                    font-family: Inter, "Open Sans", sans-serif;
-                }
-                """,
-                WebKit.UserContentInjectedFrames.TOP_FRAME,
-                WebKit.UserStyleLevel.USER,
-                null,
-                null
-            );
-
-            var user_content_manager = new WebKit.UserContentManager ();
-            user_content_manager.add_style_sheet (css);
-
-            var settings = new WebKit.Settings ();
-            settings.default_font_family = Gtk.Settings.get_default ().gtk_font_name;
-
-            var web_view = new WebKit.WebView.with_user_content_manager (user_content_manager);
-            web_view.expand = true;
-            web_view.settings = settings;
-
-            web_view.load_uri (url);
-
-            add (web_view);
-        } else {
+        if (icon_name != null) {
             var image = new Gtk.Image ();
             image.icon_name = icon_name;
             image.pixel_size = 64;
@@ -90,7 +60,6 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
             header_area.column_spacing = 12;
             header_area.halign = Gtk.Align.CENTER;
             header_area.expand = true;
-            header_area.margin_top = 6; // Give us some breathing room to match this in web views
             header_area.row_spacing = 12;
             header_area.orientation = Gtk.Orientation.VERTICAL;
             header_area.add (overlay);

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -18,6 +18,7 @@
 public class Onboarding.SyncView : AbstractOnboardingView {
     // private const string OAUTH_URL = "https://elementary.github.io/accounts-prototype/oauth";
     private const string OAUTH_URL = "http://0.0.0.0:4000/oauth";
+    private WebKit.UserContentManager user_content_manager;
 
     public SyncView () {
         Object (
@@ -27,21 +28,28 @@ public class Onboarding.SyncView : AbstractOnboardingView {
     }
 
     construct {
+        var dialog_style_context = new Gtk.Dialog ().get_style_context ();
+        var background_color = (Gdk.RGBA) dialog_style_context.get_property ("background-color", Gtk.StateFlags.NORMAL);
+        var color = (Gdk.RGBA) dialog_style_context.get_property ("color", Gtk.StateFlags.NORMAL);
+
         var css = new WebKit.UserStyleSheet (
             """
             body {
-              --background-color: #f5f5f5;
-              --color: #333;
-              --accent-color: #3689e6;
+                --background-color: %s;
+                --color: %s;
+                --accent-color: #3689e6;
             }
-            """,
+            """.printf (
+                background_color.to_string (),
+                color.to_string ()
+            ),
             WebKit.UserContentInjectedFrames.TOP_FRAME,
             WebKit.UserStyleLevel.USER,
             null,
             null
         );
 
-        var user_content_manager = new WebKit.UserContentManager ();
+        user_content_manager = new WebKit.UserContentManager ();
         user_content_manager.add_style_sheet (css);
 
         var settings = new WebKit.Settings ();

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -38,6 +38,7 @@ public class Onboarding.SyncView : AbstractOnboardingView {
                 --background-color: %s;
                 --color: %s;
                 --accent-color: #3689e6;
+                --margin: 0;
             }
             """.printf (
                 background_color.to_string (),

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -26,35 +26,36 @@ public class Onboarding.SyncView : AbstractOnboardingView {
     }
 
     construct {
-        // var css = new WebKit.UserStyleSheet (
-        //     """
-        //     :root {
-        //       --background-color: #f5f5f5;
-        //       --color: #333;
-        //     }
+        var css = new WebKit.UserStyleSheet (
+            """
+            :root {
+              --background-color: #f5f5f5;
+              --color: #333;
+            }
 
-        //     * {
-        //         color: pink;
-        //     }
-        //     """,
-        //     WebKit.UserContentInjectedFrames.TOP_FRAME,
-        //     WebKit.UserStyleLevel.AUTHOR,
-        //     null,
-        //     null
-        // );
+            * {
+                color: pink;
+            }
+            """,
+            WebKit.UserContentInjectedFrames.TOP_FRAME,
+            WebKit.UserStyleLevel.AUTHOR,
+            null,
+            null
+        );
 
-        // var user_content_manager = new WebKit.UserContentManager ();
-        // user_content_manager.add_style_sheet (css);
+        var user_content_manager = new WebKit.UserContentManager ();
+        user_content_manager.add_style_sheet (css);
 
         var settings = new WebKit.Settings ();
         settings.default_font_family = Gtk.Settings.get_default ().gtk_font_name;
 
-        var web_context = new WebKit.WebContext.ephemeral ();
-
-        // var web_view = new WebKit.WebView.with_user_content_manager (user_content_manager);
-        var web_view = new WebKit.WebView.with_context (web_context);
+        var web_view = new WebKit.WebView.with_user_content_manager (user_content_manager);
         web_view.expand = true;
         web_view.settings = settings;
+
+        // FIXME: Needs to be set before construction
+        var web_context = new WebKit.WebContext.ephemeral ();
+        web_view.web_context = web_context;
 
         web_view.load_uri (OAUTH_URL);
 

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -20,7 +20,7 @@ public class Onboarding.SyncView : AbstractOnboardingView {
         Object (
             view_name: "sync",
             title: _("elementary Sync"),
-            url: "https://accounts.elementary.io"
+            url: "https://accounts.elementary.io/auth/v1"
         );
     }
 }

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -32,6 +32,7 @@ public class Onboarding.SyncView : AbstractOnboardingView {
             body {
               --background-color: #f5f5f5;
               --color: #333;
+              --accent-color: #3689e6;
             }
             """,
             WebKit.UserContentInjectedFrames.TOP_FRAME,

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -19,8 +19,38 @@ public class Onboarding.SyncView : AbstractOnboardingView {
     public SyncView () {
         Object (
             view_name: "sync",
-            title: _("elementary Sync"),
-            url: "https://accounts.elementary.io/auth/v1"
+            title: _("elementary Sync")
         );
+    }
+
+    construct {
+        var css = new WebKit.UserStyleSheet (
+            """
+            html,
+            body {
+                background-color: #f5f5f5;
+                color: #333;
+                font-family: Inter, "Open Sans", sans-serif;
+            }
+            """,
+            WebKit.UserContentInjectedFrames.TOP_FRAME,
+            WebKit.UserStyleLevel.USER,
+            null,
+            null
+        );
+
+        var user_content_manager = new WebKit.UserContentManager ();
+        user_content_manager.add_style_sheet (css);
+
+        var settings = new WebKit.Settings ();
+        settings.default_font_family = Gtk.Settings.get_default ().gtk_font_name;
+
+        var web_view = new WebKit.WebView.with_user_content_manager (user_content_manager);
+        web_view.expand = true;
+        web_view.settings = settings;
+
+        web_view.load_uri ("https://accounts.elementary.io/auth/v1");
+
+        add (web_view);
     }
 }

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -24,28 +24,33 @@ public class Onboarding.SyncView : AbstractOnboardingView {
     }
 
     construct {
-        var css = new WebKit.UserStyleSheet (
-            """
-            html,
-            body {
-                background-color: #f5f5f5;
-                color: #333;
-                font-family: Inter, "Open Sans", sans-serif;
-            }
-            """,
-            WebKit.UserContentInjectedFrames.TOP_FRAME,
-            WebKit.UserStyleLevel.USER,
-            null,
-            null
-        );
+        // var css = new WebKit.UserStyleSheet (
+        //     """
+        //     :root {
+        //       --background-color: #f5f5f5;
+        //       --color: #333;
+        //     }
 
-        var user_content_manager = new WebKit.UserContentManager ();
-        user_content_manager.add_style_sheet (css);
+        //     * {
+        //         color: pink;
+        //     }
+        //     """,
+        //     WebKit.UserContentInjectedFrames.TOP_FRAME,
+        //     WebKit.UserStyleLevel.AUTHOR,
+        //     null,
+        //     null
+        // );
+
+        // var user_content_manager = new WebKit.UserContentManager ();
+        // user_content_manager.add_style_sheet (css);
 
         var settings = new WebKit.Settings ();
         settings.default_font_family = Gtk.Settings.get_default ().gtk_font_name;
 
-        var web_view = new WebKit.WebView.with_user_content_manager (user_content_manager);
+        var web_context = new WebKit.WebContext.ephemeral ();
+
+        // var web_view = new WebKit.WebView.with_user_content_manager (user_content_manager);
+        var web_view = new WebKit.WebView.with_context (web_context);
         web_view.expand = true;
         web_view.settings = settings;
 

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -52,5 +52,18 @@ public class Onboarding.SyncView : AbstractOnboardingView {
         web_view.load_uri ("https://accounts.elementary.io/auth/v1");
 
         add (web_view);
+
+        web_view.create.connect ((action) => { return on_new_window_requested (action); });
+    }
+
+    private Gtk.Widget? on_new_window_requested (WebKit.NavigationAction action) {
+        var uri = action.get_request ().get_uri ();
+        try {
+            AppInfo.launch_default_for_uri (uri, null);
+        } catch (Error e) {
+            warning ("Error launching browser for external link: %s", e.message);
+        }
+
+        return null;
     }
 }

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -20,7 +20,7 @@ public class Onboarding.SyncView : AbstractOnboardingView {
         Object (
             view_name: "sync",
             title: _("elementary Sync"),
-            url: "https://flatpak-auth.elementary.io/register"
+            url: "https://accounts.elementary.io"
         );
     }
 }

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -16,7 +16,8 @@
  */
 
 public class Onboarding.SyncView : AbstractOnboardingView {
-    private const string OAUTH_URL = "https://elementary.github.io/accounts-prototype/oauth";
+    // private const string OAUTH_URL = "https://elementary.github.io/accounts-prototype/oauth";
+    private const string OAUTH_URL = "http://0.0.0.0:4000/oauth";
 
     public SyncView () {
         Object (
@@ -28,13 +29,13 @@ public class Onboarding.SyncView : AbstractOnboardingView {
     construct {
         var css = new WebKit.UserStyleSheet (
             """
-            :root {
+            body {
               --background-color: #f5f5f5;
               --color: #333;
             }
             """,
             WebKit.UserContentInjectedFrames.TOP_FRAME,
-            WebKit.UserStyleLevel.AUTHOR,
+            WebKit.UserStyleLevel.USER,
             null,
             null
         );

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -32,10 +32,6 @@ public class Onboarding.SyncView : AbstractOnboardingView {
               --background-color: #f5f5f5;
               --color: #333;
             }
-
-            * {
-                color: pink;
-            }
             """,
             WebKit.UserContentInjectedFrames.TOP_FRAME,
             WebKit.UserStyleLevel.AUTHOR,

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -38,7 +38,7 @@ public class Onboarding.SyncView : AbstractOnboardingView {
                 --background-color: %s;
                 --color: %s;
                 --accent-color: #3689e6;
-                --margin: 0;
+                --padding: 0;
             }
             """.printf (
                 background_color.to_string (),

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -16,6 +16,8 @@
  */
 
 public class Onboarding.SyncView : AbstractOnboardingView {
+    private const string OAUTH_URL = "https://elementary.github.io/accounts-prototype/oauth";
+
     public SyncView () {
         Object (
             view_name: "sync",
@@ -54,7 +56,7 @@ public class Onboarding.SyncView : AbstractOnboardingView {
         web_view.expand = true;
         web_view.settings = settings;
 
-        web_view.load_uri ("https://accounts.elementary.io/auth/v1");
+        web_view.load_uri (OAUTH_URL);
 
         add (web_view);
 

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2019–2020 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+public class Onboarding.SyncView : AbstractOnboardingView {
+    public SyncView () {
+        Object (
+            view_name: "sync",
+            title: _("elementary Sync"),
+            url: "https://flatpak-auth.elementary.io/register"
+        );
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,7 @@ vala_files = [
     'Views/HouseKeepingView.vala',
     'Views/LocationServicesView.vala',
     'Views/NightLightView.vala',
+    'Views/SyncView.vala',
     'Views/UpdateView.vala',
     'Views/WelcomeView.vala',
 ]


### PR DESCRIPTION
Will fix #87

- [x] Update URL once @btkostner gives us `accounts.`
- [ ] Inject background color/styling dynamically if possible?
- [ ] Disable WebKit context menu?
- [ ] Only create view if we have Internet
- [ ] Handle losing Internet connection?
- [ ] Handle server error when loading view? i.e. auto-skip/hide?
- [x] Fix revealer with "Not Now" skip button
- [x] Open links externally just in case?
- [ ] Focus entry on sync page (focus web view when switching to that page)