### PR TITLE
SyncView: Internet without the web

### DIFF
--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -19,7 +19,7 @@ public class Onboarding.SyncView : AbstractOnboardingView {
     public SyncView () {
         Object (
             view_name: "sync",
-            description: _("Securely share app purchases and payment methods between your elementary OS devices."),
+            description: _("Securely share app purchases and payment methods between your elementary OS devices. Enter an email address to log in or sign up."),
             icon_name: Utils.logo_icon_name,
             badge_name: "emblem-synchronized",
             title: _("elementary Sync")
@@ -28,7 +28,8 @@ public class Onboarding.SyncView : AbstractOnboardingView {
 
     construct {
         var email_entry = new Gtk.Entry ();
-        email_entry.placeholder_text = "Email address";
+        email_entry.placeholder_text = _("Email address");
+        email_entry.width_request = 200;
 
         var login_button = new Gtk.Button.with_label ("Log In");
         login_button.halign = Gtk.Align.END;

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -55,6 +55,7 @@ public class Onboarding.SyncView : AbstractOnboardingView {
         instructions_grid.column_spacing = 6;
         instructions_grid.add (instructions_spinner);
         instructions_grid.add (new Gtk.Label (_("Check your email for a link to finish logging in.")));
+        // TODO: Add a "use different email address"/back button?
 
         var success_grid = new Gtk.Grid ();
         success_grid.column_spacing = 6;

--- a/src/Views/SyncView.vala
+++ b/src/Views/SyncView.vala
@@ -19,7 +19,7 @@ public class Onboarding.SyncView : AbstractOnboardingView {
     public SyncView () {
         Object (
             view_name: "sync",
-            description: _("Securely share app purchases and payment methods between your elementary OS devices. Enter an email address to log in or sign up."),
+            description: _("Securely share purchases and payment methods between your devices. Enter an email address to log in or sign up."),
             icon_name: Utils.logo_icon_name,
             badge_name: "emblem-synchronized",
             title: _("elementary Sync")
@@ -31,9 +31,9 @@ public class Onboarding.SyncView : AbstractOnboardingView {
         email_entry.placeholder_text = _("Email address");
         email_entry.width_request = 200;
 
-        var login_button = new Gtk.Button.with_label ("Log In");
-        login_button.halign = Gtk.Align.END;
-        login_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+        var next_button = new Gtk.Button.with_label (_("Next"));
+        next_button.halign = Gtk.Align.END;
+        next_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 
         var privacy_link = new Gtk.LinkButton.with_label (
             "https://elementary.io/privacy",
@@ -46,7 +46,7 @@ public class Onboarding.SyncView : AbstractOnboardingView {
         email_grid.row_spacing = 6;
         email_grid.attach (email_entry, 0, 0, 2);
         email_grid.attach (privacy_link, 0, 1);
-        email_grid.attach (login_button, 1, 1);
+        email_grid.attach (next_button, 1, 1);
 
         var instructions_spinner = new Gtk.Spinner ();
         instructions_spinner.start ();
@@ -71,7 +71,7 @@ public class Onboarding.SyncView : AbstractOnboardingView {
 
         custom_bin.add (stack);
 
-        login_button.clicked.connect (() => {
+        next_button.clicked.connect (() => {
             stack.visible_child = instructions_grid;
         });
     }


### PR DESCRIPTION
After chatting with @tintou and @btkostner in the sprint call, we totally can use Soup to log in natively with OAuth. We control the server, we control the client, and Soup supports web sockets—so a fallback webview is not needed for our primary flow.

- Trying to shoehorn an OAuth flow into a native dialog to look native plus a web view to not look native is a bunch of work that we'd need to manually keep in sync.

- Having a simple native flow plus a fallback web flow is probably actually less work over all, and less likely to have accidental breakage for users.

![Screenshot from 2020-03-14 16 53 37@2x](https://user-images.githubusercontent.com/611168/76691795-69e1b480-6614-11ea-87e9-a76f49afa43b.png)

![Screenshot from 2020-03-14 16 53 45@2x](https://user-images.githubusercontent.com/611168/76691797-6e0dd200-6614-11ea-8954-af63a87f29c3.png)

This PR switches to a native prototype for the view. Design can probably be improved.