### PR TITLE
MainWindow: lookup schemas recursive

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -53,7 +53,7 @@ public class Onboarding.MainWindow : Gtk.Window {
             paginator.add (welcome_view);
         }
 
-        var lookup = SettingsSchemaSource.get_default ().lookup (GEOCLUE_SCHEMA, false);
+        var lookup = SettingsSchemaSource.get_default ().lookup (GEOCLUE_SCHEMA, true);
         if (lookup != null) {
             var location_services_view = new LocationServicesView ();
             paginator.add (location_services_view);


### PR DESCRIPTION
The docs on SettingsSchemaSource get_default say
```
The returned source may actually consist of multiple schema sources from different directories, depending on which directories were given in `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR`. For this reason, all lookups performed against the default source should probably be done recursively.
```

Without this in NixOS it will not work as intended, as we
have multiple entries in XDG_DATA_DIRS.