### PR TITLE
Views: Better use vertical space

### DIFF
--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -54,7 +54,7 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
         header_area.column_spacing = 12;
         header_area.halign = Gtk.Align.CENTER;
         header_area.expand = true;
-        header_area.row_spacing = 12;
+        header_area.row_spacing = 6;
         header_area.orientation = Gtk.Orientation.VERTICAL;
         header_area.add (overlay);
         header_area.add (title_label);

--- a/src/Views/AppCenterView.vala
+++ b/src/Views/AppCenterView.vala
@@ -36,12 +36,14 @@ public class Onboarding.AppCenterView : AbstractOnboardingView {
             justify = Gtk.Justification.CENTER,
             max_width_chars = 45,
             use_markup = true,
+            valign = Gtk.Align.END,
+            vexpand = true,
             wrap = true
         };
         flatpak_note.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
         custom_bin.orientation = Gtk.Orientation.VERTICAL;
-        custom_bin.row_spacing = 24;
+        custom_bin.valign = Gtk.Align.FILL;
         custom_bin.add (appcenter_button);
         custom_bin.add (flatpak_note);
 

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -26,14 +26,24 @@ public class Onboarding.NightLightView : AbstractOnboardingView {
     }
 
     construct {
-        var switch_label = new Gtk.Label (_("Night Light:"));
+        var switch_label = new Gtk.Label (_("Night Light:")){
+            halign = Gtk.Align.END
+        };
 
-        var service_switch = new Gtk.Switch ();
+        var service_switch = new Gtk.Switch () {
+            halign = Gtk.Align.START
+        };
+
+        var settings_link = new Gtk.LinkButton.with_label ("settings://display/night-light", _("Adjust schedule and temperature…")) {
+            valign = Gtk.Align.END,
+            vexpand = true
+        };
 
         var settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.color");
         settings.bind ("night-light-enabled", service_switch, "active", GLib.SettingsBindFlags.DEFAULT);
 
-        custom_bin.add (switch_label);
-        custom_bin.add (service_switch);
+        custom_bin.attach (switch_label, 0, 0);
+        custom_bin.attach (service_switch, 1, 0);
+        custom_bin.attach (settings_link, 0, 1, 2);
     }
 }

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -26,7 +26,7 @@ public class Onboarding.NightLightView : AbstractOnboardingView {
     }
 
     construct {
-        var switch_label = new Gtk.Label (_("Night Light:")){
+        var switch_label = new Gtk.Label (_("Night Light:")) {
             halign = Gtk.Align.END
         };
 


### PR DESCRIPTION
Kind of hodge-podge, trying to better optimize for vertical space in preparation for #103. I was gonna do each as a separate branch, but they ended up being tiny.

- Reduces space between header lines
- Aligns AppCenter small text to bottom
- Adds a link to Night Light scheduling/temperature settings since there are more things you could want to tweak, especially if it's night time when you're Onboarding