### PR TITLE
AppCenterView: You can sideload "e.g. from Flathub"

### DIFF
--- a/src/Views/AppCenterView.vala
+++ b/src/Views/AppCenterView.vala
@@ -32,7 +32,7 @@ public class Onboarding.AppCenterView : AbstractOnboardingView {
         appcenter_button_context.add_class (Gtk.STYLE_CLASS_FLAT);
         appcenter_button_context.add_class ("link");
 
-        var flatpak_note = new Gtk.Label ("<small>%s</small>".printf (_("You can also sideload Flatpak apps i.e. from <a href='https://flathub.org'>Flathub</a>"))) {
+        var flatpak_note = new Gtk.Label ("<small>%s</small>".printf (_("You can also sideload Flatpak apps e.g. from <a href='https://flathub.org'>Flathub</a>"))) {
             justify = Gtk.Justification.CENTER,
             max_width_chars = 45,
             use_markup = true,


### PR DESCRIPTION
"You can sideload ... i.e. from Flathub" sounds as if Flathub was the only sideloading source, but there are others, like GNOME's flatpak repository.