### PR TITLE
MainWindow: Fix update view logic

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -82,13 +82,14 @@ public class Onboarding.MainWindow : Hdy.ApplicationWindow {
             carousel.add (appcenter_view);
         }
 
+        // Remove any viewed pages except the update view
         GLib.List<unowned Gtk.Widget> views = carousel.get_children ();
         foreach (Gtk.Widget view in views) {
             assert (view is AbstractOnboardingView);
 
             var view_name = ((AbstractOnboardingView) view).view_name;
 
-            if (view_name in viewed) {
+            if (view_name in viewed && view_name != "update") {
                 carousel.remove (view);
                 view.destroy ();
             }


### PR DESCRIPTION
Fixes #113. Noticed when I was working on #112. To test:

1. `gesttings reset io.elementary.onboarding viewed` to reset to a fresh install
2. Run Onboarding and step through (or skip)
3. In `dconf-editor`, remove one of the feature view names from `io.elementary.onboarding viewed` to simulate a new view showing up in an update; e.g. `location`.
4. Run Onboarding again and see that it shows the update view.
5. Repeat step 3, removing a feature name again.
6. Run Onboarding again.

In master, you will not see the update view again because it has been viewed and thus is removed from the stack. In this branch, you will see the update view again, along with whichever view you deleted from GSettings.