### PR TITLE
MainWindow: Fix Early Access detection

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -91,7 +91,7 @@ public class Onboarding.MainWindow : Hdy.ApplicationWindow {
         }
 
         // Always show Early Access view on pre-release builds
-        if (Environment.get_os_info (GLib.OsInfoKey.VERSION_CODENAME) == "next") {
+        if (Environment.get_os_info (GLib.OsInfoKey.VERSION).contains ("Early Access")) {
             var early_access_view = new EarlyAccessView ();
             carousel.add (early_access_view);
         }


### PR DESCRIPTION
We're getting lots of duplicate issues about things that are covered here again, so I'd like to get this fixed ASAP.

Checks for `Early Access` in the user-facing version string. We can just remove this when we go stable, but this gets it behaving like it did before we switched the codename.