### PR TITLE
EarlyAccessView: Align the project link center

### DIFF
--- a/src/Views/EarlyAccessView.vala
+++ b/src/Views/EarlyAccessView.vala
@@ -74,6 +74,7 @@ public class Onboarding.EarlyAccessView : AbstractOnboardingView {
             "https://github.com/orgs/elementary/projects/55",
             _("More issues on the 6.0 Release Project…")
         ) {
+            halign = Gtk.Align.CENTER,
             valign = Gtk.Align.END,
             vexpand = true
         };


### PR DESCRIPTION
Fixes there is some clickable area although no text is shown:

![2021-02-20 20 07 00 の画面録画](https://user-images.githubusercontent.com/26003928/108593518-7f7c6400-73b7-11eb-8236-e8b3ce5f294a.gif)
