### PR TITLE
Experimental: View last viewed interactive page if Onboarding was closed without completion

### DIFF
--- a/data/io.elementary.onboarding.desktop.in
+++ b/data/io.elementary.onboarding.desktop.in
@@ -8,3 +8,4 @@ Type=Application
 StartupNotify=true
 NoDisplay=true
 Categories=GNOME;GTK;System;
+X-GNOME-UsesNotifications=true

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -1,6 +1,6 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2016 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2016–2021 elementary LLC. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,7 +22,7 @@ public class Onboarding.App : Gtk.Application {
     private MainWindow window;
 
     construct {
-        application_id = "io.elementary.installer";
+        application_id = "io.elementary.onboarding";
         flags = ApplicationFlags.FLAGS_NONE;
         Intl.setlocale (LocaleCategory.ALL, "");
 
@@ -33,6 +33,12 @@ public class Onboarding.App : Gtk.Application {
 
         quit_action.activate.connect (() => {
             if (window != null) {
+                /* Send a notification to let users know
+                that they have not completed onboarding. */
+                var notification = new Notification (_("Onboarding was incomplete"));
+                notification.set_body (_("You may not have tailored your system to your preferences"));
+                send_notification ("onboarding-incomplete", notification);
+
                 window.destroy ();
             }
         });

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -33,13 +33,23 @@ public class Onboarding.App : Gtk.Application {
 
         quit_action.activate.connect (() => {
             if (window != null) {
-                /* Send a notification to let users know
-                that they have not completed onboarding. */
-                var notification = new Notification (_("Onboarding was incomplete"));
-                notification.set_body (_("You may not have tailored your system to your preferences"));
-                send_notification ("onboarding-incomplete", notification);
+                var settings = new GLib.Settings ("io.elementary.onboarding");
+                var viewed = settings.get_strv ("viewed");
 
-                window.destroy ();
+                if (!("finish" in viewed)) {
+                    /* Send a notification to let users know
+                    that they have not completed onboarding. */
+                    var notification = new Notification (_("Onboarding was incomplete"));
+                    notification.set_body (_("You may not have tailored your system to your preferences"));
+                    send_notification ("onboarding-incomplete", notification);
+                }
+
+                /* Not sure why but if the window is destroyed too quickly
+                the notification will not register. */
+                window.hide ();
+                Timeout.add (500, () => {
+                    window.destroy ();
+                });
             }
         });
     }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -19,10 +19,23 @@
  */
 
 public class Onboarding.App : Gtk.Application {
+    private MainWindow window;
+
     construct {
         application_id = "io.elementary.installer";
         flags = ApplicationFlags.FLAGS_NONE;
         Intl.setlocale (LocaleCategory.ALL, "");
+
+        var quit_action = new SimpleAction ("quit", null);
+        add_action (quit_action);
+
+        set_accels_for_action ("app.quit", {"<Control>q"});
+
+        quit_action.activate.connect (() => {
+            if (window != null) {
+                window.destroy ();
+            }
+        });
     }
 
     public override void activate () {
@@ -30,7 +43,7 @@ public class Onboarding.App : Gtk.Application {
             quit ();
         }
 
-        var window = new MainWindow ();
+        window = new MainWindow ();
         window.application = this;
         window.show_all ();
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019–2020 elementary, Inc. (https://elementary.io)
+ * Copyright 2019–2021 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -155,6 +155,10 @@ public class Onboarding.MainWindow : Hdy.ApplicationWindow {
         add (grid);
         show_all ();
 
+        if (viewed.length > 0) {
+            skip_to_earliest_interactive ();
+        }
+
         next_button.grab_focus ();
 
         carousel.notify["position"].connect (() => {
@@ -226,6 +230,21 @@ public class Onboarding.MainWindow : Hdy.ApplicationWindow {
             viewed = viewed_copy;
 
             settings.set_strv ("viewed", viewed);
+        }
+    }
+
+    /* Skip to the earliest unviewed interactive page. The list of
+    hardcoded pages here are only views that interactive.*/
+    public void skip_to_earliest_interactive () {
+        foreach (var view in carousel.get_children ()) {
+            // Cast to AbstractOnboardingView to get view_name
+            var is_interactive = ((AbstractOnboardingView) view).is_interactive;
+
+            if (is_interactive) {
+                carousel.scroll_to (view);
+
+                return;
+            }
         }
     }
 }

--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ * Copyright (c) 2019–2021 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
     public string icon_name { get; construct; }
     public string? badge_name { get; construct; }
     public string title { get; construct; }
+    public bool is_interactive { get; construct; default = false; }
 
     public Gtk.Grid custom_bin { get; private set; }
 

--- a/src/Views/HouseKeepingView.vala
+++ b/src/Views/HouseKeepingView.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ * Copyright (c) 2019–2021 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,7 +20,8 @@ public class Onboarding.HouseKeepingView : AbstractOnboardingView {
         Object (
             view_name: "housekeeping",
             icon_name: "preferences-system-privacy-housekeeping",
-            title: _("Housekeeping")
+            title: _("Housekeeping"),
+            is_interactive: true
         );
     }
 

--- a/src/Views/LocationServicesView.vala
+++ b/src/Views/LocationServicesView.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ * Copyright (c) 2019–2021 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,8 @@ public class Onboarding.LocationServicesView : AbstractOnboardingView {
             view_name: "location",
             description: _("Receive a prompt when an app requests this device’s location. If disabled, all location requests will be denied."),
             icon_name: "find-location",
-            title: _("Location Services")
+            title: _("Location Services"),
+            is_interactive: true
         );
     }
 

--- a/src/Views/NightLightView.vala
+++ b/src/Views/NightLightView.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ * Copyright (c) 2019–2021 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,8 @@ public class Onboarding.NightLightView : AbstractOnboardingView {
             view_name: "night-light",
             description: _("Make the colors of your display warmer at night to help prevent eye strain and sleeplessness."),
             icon_name: "night-light",
-            title: _("Night Light")
+            title: _("Night Light"),
+            is_interactive: true
         );
     }
 

--- a/src/Views/StyleView.vala
+++ b/src/Views/StyleView.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2020 elementary, Inc. (https://elementary.io)
+ * Copyright 2020–2021 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,7 +25,8 @@ public class Onboarding.StyleView : AbstractOnboardingView {
             view_name: "style",
             description: _("Make it your own by choosing a visual style and accent color. Apps may override these with their own look."),
             icon_name: "preferences-desktop-wallpaper",
-            title: _("Choose Your Look")
+            title: _("Choose Your Look"),
+            is_interactive: true
         );
     }
 


### PR DESCRIPTION
I put experimental in the title since this has no input from the design team.

Possible solution to close #79. This PR is incomplete but I would like input from @elementary/ux first before proceeding with the TODOs stated down below.

https://user-images.githubusercontent.com/31680656/114505563-261c0d00-9c63-11eb-8c45-801345d76bd4.mp4

This PR does the following:
- Quits the app on <kbd>CTRL</kbd>+<kbd>q</kbd>, which is the standard application quitting key.
- If at anytime the app quits when not all pages are viewed, the app sends a notification that onboarding has not yet been completed.
- Upon re-opening the onboarding app, it jumps to the first-most "interactive" page (i.e. page with switches, checkboxes, etc.)

TODOs:
- [ ] Show the close button on the window (`deletable = true` in `MainWindow` doesn't seem to work...)
- [ ] Relaunch onboarding on startup (is it required? The notification should persist on reboot anyway and if the user does not want to complete onboarding they can simply clear off the notification. If done, it will probably have to be a separate PR).