### PR TITLE
Make Expand and Margin Properties more Specific for GTK4 Porting

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -40,7 +40,8 @@ public class Onboarding.MainWindow : Hdy.ApplicationWindow {
 
     construct {
         carousel = new Hdy.Carousel () {
-            expand = true,
+            hexpand = true,
+            vexpand = true,
             valign = Gtk.Align.CENTER
         };
 
@@ -136,7 +137,8 @@ public class Onboarding.MainWindow : Hdy.ApplicationWindow {
         var action_area = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL) {
             margin_start = 10,
             margin_end = 10,
-            expand = true,
+            hexpand = true,
+            vexpand = true,
             spacing = 6,
             valign = Gtk.Align.END,
             layout_style = Gtk.ButtonBoxStyle.EDGE

--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -59,7 +59,8 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
         var header_area = new Gtk.Grid () {
             column_spacing = 12,
             halign = Gtk.Align.CENTER,
-            expand = true,
+            vexpand = true,
+            hexpand = true,
             row_spacing = 6,
             orientation = Gtk.Orientation.VERTICAL
         };
@@ -69,16 +70,19 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
 
         custom_bin = new Gtk.Grid () {
             column_spacing = 12,
-            expand = true,
+            vexpand = true,
+            hexpand = true,
             row_spacing = 6,
             halign = Gtk.Align.CENTER
         };
 
-        margin_start = margin_end = 10;
+        margin_start = 10;
+        margin_end = 10;
         margin_top = 22;
         orientation = Gtk.Orientation.VERTICAL;
         row_spacing = 24;
-        expand = true;
+        hexpand = true;
+        vexpand = true;
         add (header_area);
         add (custom_bin);
 

--- a/src/Views/StyleView.vala
+++ b/src/Views/StyleView.vala
@@ -105,9 +105,10 @@ public class Onboarding.StyleView : AbstractOnboardingView {
         var prefer_default_image = new Gtk.Image.from_resource ("/io/elementary/onboarding/appearance-default.svg");
 
         var prefer_default_card = new Gtk.Grid () {
-            margin = 6,
             margin_start = 12,
-            margin_top = 0
+            margin_top = 0,
+            margin_end = 6,
+            margin_bottom = 6
         };
         prefer_default_card.add (prefer_default_image);
 
@@ -131,9 +132,10 @@ public class Onboarding.StyleView : AbstractOnboardingView {
         var prefer_dark_image = new Gtk.Image.from_resource ("/io/elementary/onboarding/appearance-dark.svg");
 
         var prefer_dark_card = new Gtk.Grid () {
-            margin = 6,
             margin_start = 12,
-            margin_top = 0
+            margin_top = 0,
+            margin_end = 6,
+            margin_bottom = 6
         };
         prefer_dark_card.add (prefer_dark_image);
 

--- a/src/Views/StyleView.vala
+++ b/src/Views/StyleView.vala
@@ -106,7 +106,6 @@ public class Onboarding.StyleView : AbstractOnboardingView {
 
         var prefer_default_card = new Gtk.Grid () {
             margin_start = 12,
-            margin_top = 0,
             margin_end = 6,
             margin_bottom = 6
         };
@@ -133,7 +132,6 @@ public class Onboarding.StyleView : AbstractOnboardingView {
 
         var prefer_dark_card = new Gtk.Grid () {
             margin_start = 12,
-            margin_top = 0,
             margin_end = 6,
             margin_bottom = 6
         };


### PR DESCRIPTION
GTK4 does not accept `expand` and `margin` properties alone anymore. We have to specify them like `margin_start` and `hexpand`.