### PR TITLE
Replace Grid with Box for simplicity and easier GTK4 Transition

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -148,8 +148,8 @@ public class Onboarding.MainWindow : Hdy.ApplicationWindow {
         var grid = new Gtk.Box (Gtk.Orientation.VERTICAL, 24) {
             margin_bottom = 10
         };
-        grid.pack_start (carousel);
-        grid.pack_start (action_area);
+        grid.pack_start (carousel, false);
+        grid.pack_start (action_area, false);
 
         add (grid);
         show_all ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -146,13 +146,11 @@ public class Onboarding.MainWindow : Hdy.ApplicationWindow {
         action_area.add (next_button);
         action_area.set_child_non_homogeneous (switcher, true);
 
-        var grid = new Gtk.Grid () {
-            margin_bottom = 10,
-            orientation = Gtk.Orientation.VERTICAL,
-            row_spacing = 24
+        var grid = new Gtk.Box (Gtk.Orientation.VERTICAL, 24) {
+            margin_bottom = 10
         };
-        grid.add (carousel);
-        grid.add (action_area);
+        grid.pack_start (carousel);
+        grid.pack_start (action_area);
 
         add (grid);
         show_all ();

--- a/src/Switcher.vala
+++ b/src/Switcher.vala
@@ -17,7 +17,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-public class Onboarding.Switcher : Gtk.Grid {
+public class Onboarding.Switcher : Gtk.Box {
     public Hdy.Carousel carousel { get; construct; }
     private bool has_enough_children {
         get {
@@ -42,6 +42,7 @@ public class Onboarding.Switcher : Gtk.Grid {
             carousel: carousel,
             halign: Gtk.Align.CENTER,
             orientation: Gtk.Orientation.HORIZONTAL,
+            spacing: 0,
             can_focus: false
         );
     }
@@ -50,7 +51,7 @@ public class Onboarding.Switcher : Gtk.Grid {
         assert (widget is AbstractOnboardingView);
 
         var button = new PageChecker (carousel, (AbstractOnboardingView) widget);
-        add (button);
+        pack_start (button);
     }
 
     public override void show () {

--- a/src/Switcher.vala
+++ b/src/Switcher.vala
@@ -51,7 +51,7 @@ public class Onboarding.Switcher : Gtk.Box {
         assert (widget is AbstractOnboardingView);
 
         var button = new PageChecker (carousel, (AbstractOnboardingView) widget);
-        pack_start (button);
+        pack_start (button, false);
     }
 
     public override void show () {

--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -56,16 +56,13 @@ public abstract class AbstractOnboardingView : Gtk.Box {
             use_markup = true
         };
 
-        var header_area = new Gtk.Grid () {
-            column_spacing = 12,
+        var header_area = new Gtk.Box (Gtk.Orientation.VERTICAL, 6) {
             halign = Gtk.Align.CENTER,
-            expand = true,
-            row_spacing = 6,
-            orientation = Gtk.Orientation.VERTICAL
+            expand = true
         };
-        header_area.add (overlay);
-        header_area.add (title_label);
-        header_area.add (description_label);
+        header_area.pack_start (overlay);
+        header_area.pack_start (title_label);
+        header_area.pack_start (description_label);
 
         custom_bin = new Gtk.Grid () {
             column_spacing = 12,

--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -61,9 +61,9 @@ public abstract class AbstractOnboardingView : Gtk.Box {
             vexpand = true,
             hexpand = true
         };
-        header_area.pack_start (overlay);
-        header_area.pack_start (title_label);
-        header_area.pack_start (description_label);
+        header_area.pack_start (overlay, false);
+        header_area.pack_start (title_label, false);
+        header_area.pack_start (description_label, false);
 
         custom_bin = new Gtk.Grid () {
             column_spacing = 12,
@@ -80,8 +80,8 @@ public abstract class AbstractOnboardingView : Gtk.Box {
         spacing = 24;
         hexpand = true;
         vexpand = true;
-        pack_start (header_area);
-        pack_start (custom_bin);
+        pack_start (header_area, false);
+        pack_start (custom_bin, false);
 
         bind_property ("description", description_label, "label");
     }

--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public abstract class AbstractOnboardingView : Gtk.Grid {
+public abstract class AbstractOnboardingView : Gtk.Box {
     public string view_name { get; construct; }
     public string description { get; set; }
     public string icon_name { get; construct; }
@@ -77,10 +77,10 @@ public abstract class AbstractOnboardingView : Gtk.Grid {
         margin_start = margin_end = 10;
         margin_top = 22;
         orientation = Gtk.Orientation.VERTICAL;
-        row_spacing = 24;
+        spacing = 24;
         expand = true;
-        add (header_area);
-        add (custom_bin);
+        pack_start (header_area);
+        pack_start (custom_bin);
 
         bind_property ("description", description_label, "label");
     }

--- a/src/Views/HouseKeepingView.vala
+++ b/src/Views/HouseKeepingView.vala
@@ -27,9 +27,9 @@ public class Onboarding.HouseKeepingView : AbstractOnboardingView {
     construct {
         var header_label = new Granite.HeaderLabel (_("Automatically Delete:"));
 
-        var temp_grid = new Gtk.Grid ();
-        temp_grid.add (new Gtk.Image.from_icon_name ("folder", Gtk.IconSize.LARGE_TOOLBAR));
-        temp_grid.add (new Gtk.Label (_("Old temporary files")));
+        var temp_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        temp_grid.pack_start (new Gtk.Image.from_icon_name ("folder", Gtk.IconSize.LARGE_TOOLBAR));
+        temp_grid.pack_start (new Gtk.Label (_("Old temporary files")));
 
         var temp_check = new Gtk.CheckButton () {
             halign = Gtk.Align.START,
@@ -37,9 +37,9 @@ public class Onboarding.HouseKeepingView : AbstractOnboardingView {
         };
         temp_check.add (temp_grid);
 
-        var download_grid = new Gtk.Grid ();
-        download_grid.add (new Gtk.Image.from_icon_name ("folder-download", Gtk.IconSize.LARGE_TOOLBAR));
-        download_grid.add (new Gtk.Label (_("Downloaded files")));
+        var download_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        download_grid.pack_start (new Gtk.Image.from_icon_name ("folder-download", Gtk.IconSize.LARGE_TOOLBAR));
+        download_grid.pack_start (new Gtk.Label (_("Downloaded files")));
 
         var download_check = new Gtk.CheckButton () {
             halign = Gtk.Align.START,
@@ -47,9 +47,9 @@ public class Onboarding.HouseKeepingView : AbstractOnboardingView {
         };
         download_check.add (download_grid);
 
-        var trash_grid = new Gtk.Grid ();
-        trash_grid.add (new Gtk.Image.from_icon_name ("user-trash-full", Gtk.IconSize.LARGE_TOOLBAR));
-        trash_grid.add (new Gtk.Label (_("Trashed files")));
+        var trash_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        trash_grid.pack_start (new Gtk.Image.from_icon_name ("user-trash-full", Gtk.IconSize.LARGE_TOOLBAR));
+        trash_grid.pack_start (new Gtk.Label (_("Trashed files")));
 
         var trash_check = new Gtk.CheckButton () {
             halign = Gtk.Align.START,

--- a/src/Views/HouseKeepingView.vala
+++ b/src/Views/HouseKeepingView.vala
@@ -28,8 +28,8 @@ public class Onboarding.HouseKeepingView : AbstractOnboardingView {
         var header_label = new Granite.HeaderLabel (_("Automatically Delete:"));
 
         var temp_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-        temp_grid.pack_start (new Gtk.Image.from_icon_name ("folder", Gtk.IconSize.LARGE_TOOLBAR));
-        temp_grid.pack_start (new Gtk.Label (_("Old temporary files")));
+        temp_grid.pack_start (new Gtk.Image.from_icon_name ("folder", Gtk.IconSize.LARGE_TOOLBAR), false);
+        temp_grid.pack_start (new Gtk.Label (_("Old temporary files")), false);
 
         var temp_check = new Gtk.CheckButton () {
             halign = Gtk.Align.START,
@@ -38,8 +38,9 @@ public class Onboarding.HouseKeepingView : AbstractOnboardingView {
         temp_check.add (temp_grid);
 
         var download_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-        download_grid.pack_start (new Gtk.Image.from_icon_name ("folder-download", Gtk.IconSize.LARGE_TOOLBAR));
-        download_grid.pack_start (new Gtk.Label (_("Downloaded files")));
+        download_grid.pack_start (new Gtk.Image.from_icon_name ("folder-download",
+            Gtk.IconSize.LARGE_TOOLBAR), false);
+        download_grid.pack_start (new Gtk.Label (_("Downloaded files")), false);
 
         var download_check = new Gtk.CheckButton () {
             halign = Gtk.Align.START,
@@ -48,8 +49,9 @@ public class Onboarding.HouseKeepingView : AbstractOnboardingView {
         download_check.add (download_grid);
 
         var trash_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-        trash_grid.pack_start (new Gtk.Image.from_icon_name ("user-trash-full", Gtk.IconSize.LARGE_TOOLBAR));
-        trash_grid.pack_start (new Gtk.Label (_("Trashed files")));
+        trash_grid.pack_start (new Gtk.Image.from_icon_name ("user-trash-full",
+            Gtk.IconSize.LARGE_TOOLBAR), false);
+        trash_grid.pack_start (new Gtk.Label (_("Trashed files")), false);
 
         var trash_check = new Gtk.CheckButton () {
             halign = Gtk.Align.START,

--- a/src/Views/StyleView.vala
+++ b/src/Views/StyleView.vala
@@ -102,14 +102,15 @@ public class Onboarding.StyleView : AbstractOnboardingView {
             }
         }
 
-        var prefer_default_image = new Gtk.Image.from_resource ("/io/elementary/onboarding/appearance-default.svg");
+        var prefer_default_image = new Gtk.Image.from_resource (
+            "/io/elementary/onboarding/appearance-default.svg");
 
         var prefer_default_card = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
             margin_start = 12,
             margin_end = 6,
             margin_bottom = 6
         };
-        prefer_default_card.pack_start (prefer_default_image);
+        prefer_default_card.pack_start (prefer_default_image, false);
 
         unowned Gtk.StyleContext prefer_default_card_context = prefer_default_card.get_style_context ();
         prefer_default_card_context.add_class (Granite.STYLE_CLASS_CARD);
@@ -117,8 +118,8 @@ public class Onboarding.StyleView : AbstractOnboardingView {
         prefer_default_card_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var prefer_default_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
-        prefer_default_box.pack_start (prefer_default_card);
-        prefer_default_box.pack_start (new Gtk.Label (_("Default")));
+        prefer_default_box.pack_start (prefer_default_card, false);
+        prefer_default_box.pack_start (new Gtk.Label (_("Default")), false);
 
         var prefer_default_radio = new Gtk.RadioButton (null) {
             halign = Gtk.Align.END,
@@ -134,7 +135,7 @@ public class Onboarding.StyleView : AbstractOnboardingView {
             margin_end = 6,
             margin_bottom = 6
         };
-        prefer_dark_card.pack_start (prefer_dark_image);
+        prefer_dark_card.pack_start (prefer_dark_image, false);
 
         unowned Gtk.StyleContext prefer_dark_card_context = prefer_dark_card.get_style_context ();
         prefer_dark_card_context.add_class (Granite.STYLE_CLASS_CARD);
@@ -189,17 +190,17 @@ public class Onboarding.StyleView : AbstractOnboardingView {
         var accent_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
             halign = Gtk.Align.CENTER
         };
-        accent_box.pack_start (blueberry_button);
-        accent_box.pack_start (mint_button);
-        accent_box.pack_start (lime_button);
-        accent_box.pack_start (banana_button);
-        accent_box.pack_start (orange_button);
-        accent_box.pack_start (strawberry_button);
-        accent_box.pack_start (bubblegum_button);
-        accent_box.pack_start (grape_button);
-        accent_box.pack_start (cocoa_button);
-        accent_box.pack_start (slate_button);
-        accent_box.pack_start (auto_button);
+        accent_box.pack_start (blueberry_button, false);
+        accent_box.pack_start (mint_button, false);
+        accent_box.pack_start (lime_button, false);
+        accent_box.pack_start (banana_button, false);
+        accent_box.pack_start (orange_button, false);
+        accent_box.pack_start (strawberry_button, false);
+        accent_box.pack_start (bubblegum_button, false);
+        accent_box.pack_start (grape_button, false);
+        accent_box.pack_start (cocoa_button, false);
+        accent_box.pack_start (slate_button, false);
+        accent_box.pack_start (auto_button, false);
 
         custom_bin.row_spacing = 12;
         custom_bin.attach (prefer_default_radio, 0, 0);

--- a/src/Views/StyleView.vala
+++ b/src/Views/StyleView.vala
@@ -116,17 +116,16 @@ public class Onboarding.StyleView : AbstractOnboardingView {
         prefer_default_card_context.add_class (Granite.STYLE_CLASS_ROUNDED);
         prefer_default_card_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        var prefer_default_grid = new Gtk.Grid ();
-        prefer_default_grid.row_spacing = 6;
-        prefer_default_grid.attach (prefer_default_card, 0, 0);
-        prefer_default_grid.attach (new Gtk.Label (_("Default")), 0, 1);
+        var prefer_default_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
+        prefer_default_box.pack_start (prefer_default_card);
+        prefer_default_box.pack_start (new Gtk.Label (_("Default")));
 
         var prefer_default_radio = new Gtk.RadioButton (null) {
             halign = Gtk.Align.END,
             hexpand = true
         };
         prefer_default_radio.get_style_context ().add_class ("image-button");
-        prefer_default_radio.add (prefer_default_grid);
+        prefer_default_radio.add (prefer_default_box);
 
         var prefer_dark_image = new Gtk.Image.from_resource ("/io/elementary/onboarding/appearance-dark.svg");
 
@@ -187,26 +186,25 @@ public class Onboarding.StyleView : AbstractOnboardingView {
         var auto_button = new PrefersAccentColorButton (pantheon_act, AccentColor.NO_PREFERENCE, blueberry_button);
         auto_button.tooltip_text = _("Automatic based on wallpaper");
 
-        var accent_grid = new Gtk.Grid () {
-            column_spacing = 6,
+        var accent_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
             halign = Gtk.Align.CENTER
         };
-        accent_grid.add (blueberry_button);
-        accent_grid.add (mint_button);
-        accent_grid.add (lime_button);
-        accent_grid.add (banana_button);
-        accent_grid.add (orange_button);
-        accent_grid.add (strawberry_button);
-        accent_grid.add (bubblegum_button);
-        accent_grid.add (grape_button);
-        accent_grid.add (cocoa_button);
-        accent_grid.add (slate_button);
-        accent_grid.add (auto_button);
+        accent_box.pack_start (blueberry_button);
+        accent_box.pack_start (mint_button);
+        accent_box.pack_start (lime_button);
+        accent_box.pack_start (banana_button);
+        accent_box.pack_start (orange_button);
+        accent_box.pack_start (strawberry_button);
+        accent_box.pack_start (bubblegum_button);
+        accent_box.pack_start (grape_button);
+        accent_box.pack_start (cocoa_button);
+        accent_box.pack_start (slate_button);
+        accent_box.pack_start (auto_button);
 
         custom_bin.row_spacing = 12;
         custom_bin.attach (prefer_default_radio, 0, 0);
         custom_bin.attach (prefer_dark_radio, 1, 0);
-        custom_bin.attach (accent_grid, 0, 1, 2);
+        custom_bin.attach (accent_box, 0, 1, 2);
 
         switch (pantheon_act.prefers_color_scheme) {
             case Granite.Settings.ColorScheme.DARK:

--- a/src/Views/StyleView.vala
+++ b/src/Views/StyleView.vala
@@ -104,12 +104,12 @@ public class Onboarding.StyleView : AbstractOnboardingView {
 
         var prefer_default_image = new Gtk.Image.from_resource ("/io/elementary/onboarding/appearance-default.svg");
 
-        var prefer_default_card = new Gtk.Grid () {
+        var prefer_default_card = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
             margin = 6,
             margin_start = 12,
             margin_top = 0
         };
-        prefer_default_card.add (prefer_default_image);
+        prefer_default_card.pack_start (prefer_default_image);
 
         unowned Gtk.StyleContext prefer_default_card_context = prefer_default_card.get_style_context ();
         prefer_default_card_context.add_class (Granite.STYLE_CLASS_CARD);
@@ -130,12 +130,12 @@ public class Onboarding.StyleView : AbstractOnboardingView {
 
         var prefer_dark_image = new Gtk.Image.from_resource ("/io/elementary/onboarding/appearance-dark.svg");
 
-        var prefer_dark_card = new Gtk.Grid () {
+        var prefer_dark_card = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
             margin = 6,
             margin_start = 12,
             margin_top = 0
         };
-        prefer_dark_card.add (prefer_dark_image);
+        prefer_dark_card.pack_start (prefer_dark_image);
 
         unowned Gtk.StyleContext prefer_dark_card_context = prefer_dark_card.get_style_context ();
         prefer_dark_card_context.add_class (Granite.STYLE_CLASS_CARD);

--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -69,9 +69,10 @@ public class Onboarding.WelcomeView : AbstractOnboardingView {
             };
 
             var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-            box.pack_start (image);
-            box.pack_start (left_label);
+            box.pack_start (image, false);
+            box.pack_start (left_label, false);
 
+            halign = Gtk.Align.START;
             add (box);
         }
     }

--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -68,11 +68,11 @@ public class Onboarding.WelcomeView : AbstractOnboardingView {
                 xalign = 0
             };
 
-            var grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-            grid.pack_start (image);
-            grid.pack_start (left_label);
+            var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            box.pack_start (image);
+            box.pack_start (left_label);
 
-            add (grid);
+            add (box);
         }
     }
 }

--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -68,9 +68,9 @@ public class Onboarding.WelcomeView : AbstractOnboardingView {
                 xalign = 0
             };
 
-            var grid = new Gtk.Grid ();
-            grid.add (image);
-            grid.add (left_label);
+            var grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            grid.pack_start (image);
+            grid.pack_start (left_label);
 
             add (grid);
         }


### PR DESCRIPTION
There are `Gtk.Grid`s with `add` that can be replaced with `Box` and `pack_start`, so that in GTK4 Transition we can just replace `pack_start` with `append`.