### PR TITLE
Remove unused signal

### DIFF
--- a/src/Switcher.vala
+++ b/src/Switcher.vala
@@ -25,8 +25,6 @@ public class Onboarding.Switcher : Gtk.Grid {
         }
     }
 
-    public signal void on_carousel_changed ();
-
     construct {
         show_all ();
 


### PR DESCRIPTION
The `on_carousel_changed` signal is not used so it can be safely removed.