### PR TITLE
StyleView: handle NO_PREFERENCE in switch

### DIFF
--- a/src/Views/StyleView.vala
+++ b/src/Views/StyleView.vala
@@ -57,9 +57,10 @@ public class Onboarding.StyleView : AbstractOnboardingView {
                     return "cocoa";
                 case GRAY:
                     return "slate";
+                case NO_PREFERENCE:
+                default:
+                    return "auto";
             }
-
-            return "auto";
         }
     }
 
@@ -243,8 +244,6 @@ public class Onboarding.StyleView : AbstractOnboardingView {
 
         static construct {
             interface_settings = new GLib.Settings (INTERFACE_SCHEMA);
-
-            var current_stylesheet = interface_settings.get_string (STYLESHEET_KEY);
         }
 
         construct {

--- a/src/Views/StyleView.vala
+++ b/src/Views/StyleView.vala
@@ -57,7 +57,6 @@ public class Onboarding.StyleView : AbstractOnboardingView {
                     return "cocoa";
                 case GRAY:
                     return "slate";
-                case NO_PREFERENCE:
                 default:
                     return "auto";
             }


### PR DESCRIPTION
Fixes a compiler warning

Also, while I'm here, remove a cached preference we never do anything with