### PR TITLE
MainWindow: warn about daily builds

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -50,9 +50,17 @@ public class Onboarding.MainWindow : Gtk.ApplicationWindow {
         }
 
         // Always show Early Access view on pre-release builds
-        if (Environment.get_os_info (GLib.OsInfoKey.VERSION).contains ("Early Access")) {
-            var early_access_view = new EarlyAccessView ();
-            carousel.append (early_access_view);
+        var apt_sources = File.new_for_path ("/etc/apt/sources.list.d/elementary.list");
+        try {
+            var @is = apt_sources.read ();
+            var dis = new DataInputStream (@is);
+
+            if ("daily" in dis.read_line ()) {
+                var early_access_view = new EarlyAccessView ();
+                carousel.append (early_access_view);
+            }
+        } catch (Error e) {
+            critical ("Couldn't read apt sources: %s", e.message);
         }
 
         if ("finish" in viewed) {


### PR DESCRIPTION
Related to https://github.com/elementary/installer/pull/668

Screenshots are taken on OS 7 daily.

## Before

![Bildschirmfoto von 2022-11-28 20 53 35](https://user-images.githubusercontent.com/10796736/204369966-023b33e4-e419-4dd2-ab92-034da1b3a2fa.png)

## After

![Bildschirmfoto von 2022-11-28 20 59 22](https://user-images.githubusercontent.com/10796736/204369991-7292c5da-c109-4c09-b16c-a08c4d555836.png)
