### PR TITLE
EarlyAccessView: use applications-development for icon

### DIFF
--- a/src/Views/EarlyAccessView.vala
+++ b/src/Views/EarlyAccessView.vala
@@ -23,8 +23,7 @@ public class Onboarding.EarlyAccessView : AbstractOnboardingView {
         Object (
             view_name: "early-access",
             description: _("This pre-release version of %s should not be used in production. <b>It will not be possible to upgrade to the stable release</b> from this installation.").printf (Utils.os_name),
-            icon_name: Utils.logo_icon_name,
-            badge_name: "dialog-warning",
+            icon_name: "applications-development",
             title: _("Early Access Build")
         );
     }


### PR DESCRIPTION
We're using the same icon in Installer: https://github.com/elementary/installer/pull/665

![Screenshot from 2022-12-27 15 34 48](https://user-images.githubusercontent.com/7277719/209736560-dfc38533-ed30-45e1-8163-ddef980ec9ef.png)
