### PR TITLE
WelcomeView: adjust button spacing, shorten title

### DIFF
--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -21,7 +21,7 @@ public class Onboarding.WelcomeView : AbstractOnboardingView {
             view_name: "welcome",
             description: _("Continue to set up some useful features. Visit the links below for more information about %s.").printf (Utils.os_name),
             icon_name: Utils.logo_icon_name,
-            title: _("Welcome to %s!").printf (Utils.os_name)
+            title: _("Welcome!")
         );
     }
 
@@ -44,6 +44,7 @@ public class Onboarding.WelcomeView : AbstractOnboardingView {
             "applications-development-symbolic"
         );
 
+        custom_bin.spacing = 3;
         custom_bin.append (thebasics_link);
         custom_bin.append (support_link);
         custom_bin.append (getinvolved_link);
@@ -76,7 +77,7 @@ public class Onboarding.WelcomeView : AbstractOnboardingView {
                 xalign = 0
             };
 
-            var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 3);
             box.append (image);
             box.append (left_label);
 


### PR DESCRIPTION
* Title area is really heavy so remove OS name. I think less is more here, we don't need to announce the OS name over and over
* Adjust button spacing. We have to take into consideration the vertical spacing from the linkbutton.

## BEFORE
![Screenshot from 2023-03-28 19 31 55](https://user-images.githubusercontent.com/7277719/228411372-6c95ca62-85b5-4dec-9a8c-123daef9744e.png)

## AFTER
![Screenshot from 2023-03-28 19 31 09](https://user-images.githubusercontent.com/7277719/228411378-a5b515de-6d9e-4ac0-80e3-4477ac279e76.png)
