### PR TITLE
Allow focusing PageChecker, scroll to View when it contains focus

### DIFF
--- a/src/PageChecker.vala
+++ b/src/PageChecker.vala
@@ -30,13 +30,6 @@ public class Onboarding.PageChecker : Gtk.Button {
     public PageChecker (Adw.Carousel carousel, AbstractOnboardingView page) {
         Object (carousel: carousel, page: page);
     }
-
-    private void update_opacity () {
-        double progress = double.max (1 - (carousel.position - page_number).abs (), 0);
-
-        opacity = MIN_OPACITY + (1 - MIN_OPACITY) * progress;
-    }
-
     construct {
         icon_name = "pager-checked-symbolic";
 
@@ -61,5 +54,11 @@ public class Onboarding.PageChecker : Gtk.Button {
         page.destroy.connect (() => {
             destroy ();
         });
+    }
+
+    private void update_opacity () {
+        double progress = double.max (1 - (carousel.position - page_number).abs (), 0);
+
+        child.opacity = MIN_OPACITY + (1 - MIN_OPACITY) * progress;
     }
 }

--- a/src/Switcher.vala
+++ b/src/Switcher.vala
@@ -26,8 +26,11 @@ public class Onboarding.Switcher : Gtk.Box {
         }
     }
 
-    construct {
+    public Switcher (Adw.Carousel carousel) {
+        Object (carousel: carousel);
+    }
 
+    construct {
         for (var child_index = 0; child_index < carousel.get_n_pages (); child_index++) {
             var child = carousel.get_nth_page (child_index);
             add_child (child);
@@ -39,15 +42,7 @@ public class Onboarding.Switcher : Gtk.Box {
         });
     }
 
-    public Switcher (Adw.Carousel carousel) {
-        Object (
-            carousel: carousel,
-            halign: Gtk.Align.CENTER,
-            can_focus: false,
-            orientation: Gtk.Orientation.HORIZONTAL,
-            spacing: 0
-        );
-    }
+
 
     private void add_child (Gtk.Widget widget) {
         assert (widget is AbstractOnboardingView);

--- a/src/Views/AbstractOnboardingView.vala
+++ b/src/Views/AbstractOnboardingView.vala
@@ -86,6 +86,15 @@ public abstract class AbstractOnboardingView : Gtk.Box {
         append (custom_bin);
 
         bind_property ("description", description_label, "label");
+
+        var focus_controller = new Gtk.EventControllerFocus ();
+        add_controller (focus_controller);
+
+        // FIXME: workaround for https://gitlab.gnome.org/GNOME/libadwaita/-/issues/724
+        focus_controller.notify["contains-focus"].connect (() => {
+            var carousel = (Adw.Carousel) get_ancestor (typeof (Adw.Carousel));
+            carousel.scroll_to (this, true);
+        });
     }
 
     public class ListItem : Gtk.Box {


### PR DESCRIPTION
Fixes #217 
Contains a workaround for https://gitlab.gnome.org/GNOME/libadwaita/-/issues/724

For at least what can be fixed within the scope of Onboarding, by making page checker buttons focusable and making sure we only dim the image child, not the focus style