### PR TITLE
Actions: Make sure to use latest gettext-template; remove git installation

### DIFF
--- a/.github/workflows/gettext.yml
+++ b/.github/workflows/gettext.yml
@@ -5,24 +5,17 @@ on:
     branches: [master]
 
 jobs:
-  build:
-    runs-on: ubuntu-22.04
-    container:
-      image: ghcr.io/elementary/docker:next-unstable
+  gettext_template:
+    runs-on: ubuntu-latest
 
     steps:
-    - name: Install git
-      run: |
-        apt-get update
-        apt-get install git -y
-
     - name: Clone repository
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.GIT_USER_TOKEN }}
 
     - name: Update Translation Files
-      uses: elementary/actions/gettext-template@next
+      uses: elementary/actions/gettext-template@main
       env:
         GIT_USER_TOKEN: ${{ secrets.GIT_USER_TOKEN }}
         GIT_USER_NAME: "elementaryBot"


### PR DESCRIPTION
Same fix with elementary/switchboard-plug-sharing#72

This should fix the gettext actions failing in latest master branch