### PR TITLE
Control: bump settings-daemon runtime dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Standards-Version: 4.1.1
 
 Package: io.elementary.onboarding
 Architecture: any
-Depends: io.elementary.settings-daemon (>=8.0.0),
+Depends: io.elementary.settings-daemon (>=8.4.0),
          ${misc:Depends},
          ${shlibs:Depends}
 Description: Change common settings on first-run


### PR DESCRIPTION
8.4.0 is when Latte is included in settings daemon